### PR TITLE
Fix insert statement for MySQL

### DIFF
--- a/src/Dommel/DommelMapper.cs
+++ b/src/Dommel/DommelMapper.cs
@@ -1480,7 +1480,7 @@ namespace Dommel
         {
             public string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty)
             {
-                return string.Format("insert into {0} ({1}) values ({2}) select LAST_INSERT_ID() id",
+                return string.Format("insert into {0} ({1}) values ({2}); select LAST_INSERT_ID() id",
                     tableName,
                     string.Join(", ", columnNames),
                     string.Join(", ", paramNames));


### PR DESCRIPTION
For the insert statement to work, a semicolon is needed for MySQL. Otherwise, an exception is thrown. 