### PR TITLE
Add Extensibility for Update Builder Interface

### DIFF
--- a/src/Dommel/DommelMapper.cs
+++ b/src/Dommel/DommelMapper.cs
@@ -1257,11 +1257,11 @@ namespace Dommel
         /// <returns>A value indicating whether the update operation succeeded.</returns>
         public static async Task<bool> UpdateAsync<TEntity>(this IDbConnection connection, TEntity entity, IDbTransaction transaction = null)
         {
-            var sql = BuildUpdateQuery(typeof(TEntity));
+            var sql = BuildUpdateQuery(typeof(TEntity), connection);
             return await connection.ExecuteAsync(sql, entity, transaction) > 0;
         }
 
-        private static string BuildUpdateQuery(Type type, IDbConnection connection = null)
+        private static string BuildUpdateQuery(Type type, IDbConnection connection)
         {
             string sql;
             if (!_updateQueryCache.TryGetValue(type, out sql))


### PR DESCRIPTION
I am working on a legacy application and needed some extension points into an Access Database. I figured, rather than roll my own Dapper integration, I'd just add a couple extensibility points in here and see if you're interested in bringing them in.

Main thing is the inclusion of IUpdateBuilder - Access (and apparently OleDB in general) requires weird parameters - `?ParameterName?` instead of `@ParameterName`.

Dapper supports this - but I had to go through and fix a few things to get it into Dommel.

Feel free to request changes or whatever - I see you're working on a V2 - I'd be happy to wrap these changes into that.
