### PR TITLE
Surround table and column names with open and close square brackets for SQL Server

### DIFF
--- a/src/Dommel/DommelMapper.Get.cs
+++ b/src/Dommel/DommelMapper.Get.cs
@@ -1,11 +1,10 @@
+using Dapper;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Dapper;
 
 namespace Dommel
 {
@@ -18,12 +17,13 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static TEntity Get<TEntity>(this IDbConnection connection, object id, IDbTransaction transaction = null) where TEntity : class
+        public static TEntity Get<TEntity>(this IDbConnection connection, object id, IDbTransaction transaction = null, int? commandTimeout = null) where TEntity : class
         {
             var sql = BuildGetById(connection, typeof(TEntity), id, out var parameters);
             LogQuery<TEntity>(sql);
-            return connection.QueryFirstOrDefault<TEntity>(sql, parameters, transaction);
+            return connection.QueryFirstOrDefault<TEntity>(sql, parameters, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -33,12 +33,13 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object id, IDbTransaction transaction = null) where TEntity : class
+        public static Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object id, IDbTransaction transaction = null, int? commandTimeout = null) where TEntity : class
         {
             var sql = BuildGetById(connection, typeof(TEntity), id, out var parameters);
             LogQuery<TEntity>(sql);
-            return connection.QueryFirstOrDefaultAsync<TEntity>(sql, parameters, transaction);
+            return connection.QueryFirstOrDefaultAsync<TEntity>(sql, parameters, transaction, commandTimeout);
         }
 
         private static string BuildGetById(IDbConnection connection, Type type, object id, out DynamicParameters parameters)
@@ -78,17 +79,18 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="ids">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static TEntity Get<TEntity>(this IDbConnection connection, object[] ids, IDbTransaction transaction = null) where TEntity : class
+        public static TEntity Get<TEntity>(this IDbConnection connection, object[] ids, IDbTransaction transaction = null, int? commandTimeout = null) where TEntity : class
         {
             if (ids.Length == 1)
             {
-                return Get<TEntity>(connection, ids[0], transaction);
+                return Get<TEntity>(connection, ids[0], transaction, commandTimeout);
             }
 
             var sql = BuildGetByIds(connection, typeof(TEntity), ids, out var parameters);
             LogQuery<TEntity>(sql);
-            return connection.QueryFirstOrDefault<TEntity>(sql, parameters);
+            return connection.QueryFirstOrDefault<TEntity>(sql, parameters, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -108,17 +110,18 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="ids">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object[] ids, IDbTransaction transaction = null) where TEntity : class
+        public static Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object[] ids, IDbTransaction transaction = null, int? commandTimeout = null) where TEntity : class
         {
             if (ids.Length == 1)
             {
-                return GetAsync<TEntity>(connection, ids[0], transaction);
+                return GetAsync<TEntity>(connection, ids[0], transaction, commandTimeout);
             }
 
             var sql = BuildGetByIds(connection, typeof(TEntity), ids, out var parameters);
             LogQuery<TEntity>(sql);
-            return connection.QueryFirstOrDefaultAsync<TEntity>(sql, parameters);
+            return connection.QueryFirstOrDefaultAsync<TEntity>(sql, parameters, transaction, commandTimeout);
         }
 
         private static string BuildGetByIds(IDbConnection connection, Type type, object[] ids, out DynamicParameters parameters)
@@ -166,17 +169,18 @@ namespace Dommel
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
+        /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="buffered">
         /// A value indicating whether the result of the query should be executed directly,
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
-        /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>A collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static IEnumerable<TEntity> GetAll<TEntity>(this IDbConnection connection, IDbTransaction transaction = null, bool buffered = true) where TEntity : class
+        public static IEnumerable<TEntity> GetAll<TEntity>(this IDbConnection connection, IDbTransaction transaction = null, bool buffered = true, int? commandTimeout = null) where TEntity : class
         {
             var sql = BuildGetAllQuery(connection, typeof(TEntity));
             LogQuery<TEntity>(sql);
-            return connection.Query<TEntity>(sql, transaction: transaction, buffered: buffered);
+            return connection.Query<TEntity>(sql, transaction: transaction, buffered: buffered, commandTimeout: commandTimeout);
         }
 
         /// <summary>
@@ -185,12 +189,13 @@ namespace Dommel
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>A collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static Task<IEnumerable<TEntity>> GetAllAsync<TEntity>(this IDbConnection connection, IDbTransaction transaction = null) where TEntity : class
+        public static Task<IEnumerable<TEntity>> GetAllAsync<TEntity>(this IDbConnection connection, IDbTransaction transaction = null, int? commandTimeout = null) where TEntity : class
         {
             var sql = BuildGetAllQuery(connection, typeof(TEntity));
             LogQuery<TEntity>(sql);
-            return connection.QueryAsync<TEntity>(sql, transaction: transaction);
+            return connection.QueryAsync<TEntity>(sql, transaction: transaction, commandTimeout: commandTimeout);
         }
 
         private static string BuildGetAllQuery(IDbConnection connection, Type type)
@@ -212,17 +217,18 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="pageNumber">The number of the page to fetch, starting at 1.</param>
         /// <param name="pageSize">The page size.</param>
+        /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="buffered">
         /// A value indicating whether the result of the query should be executed directly,
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
-        /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>A paged collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static IEnumerable<TEntity> GetPaged<TEntity>(this IDbConnection connection, int pageNumber, int pageSize, IDbTransaction transaction = null, bool buffered = true) where TEntity : class
+        public static IEnumerable<TEntity> GetPaged<TEntity>(this IDbConnection connection, int pageNumber, int pageSize, IDbTransaction transaction = null, bool buffered = true, int? commandTimeout = null) where TEntity : class
         {
             var sql = BuildPagedQuery(connection, typeof(TEntity), pageNumber, pageSize);
             LogQuery<TEntity>(sql);
-            return connection.Query<TEntity>(sql, transaction: transaction, buffered: buffered);
+            return connection.Query<TEntity>(sql, transaction: transaction, buffered: buffered, commandTimeout: commandTimeout);
         }
 
         /// <summary>
@@ -233,12 +239,13 @@ namespace Dommel
         /// <param name="pageNumber">The number of the page to fetch, starting at 1.</param>
         /// <param name="pageSize">The page size.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
+        /// <param name="commandTimeout">The command timeout (in seconds).</param>
         /// <returns>A paged collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static Task<IEnumerable<TEntity>> GetPagedAsync<TEntity>(this IDbConnection connection, int pageNumber, int pageSize, IDbTransaction transaction = null) where TEntity : class
+        public static Task<IEnumerable<TEntity>> GetPagedAsync<TEntity>(this IDbConnection connection, int pageNumber, int pageSize, IDbTransaction transaction = null, int? commandTimeout = null) where TEntity : class
         {
             var sql = BuildPagedQuery(connection, typeof(TEntity), pageNumber, pageSize);
             LogQuery<TEntity>(sql);
-            return connection.QueryAsync<TEntity>(sql, transaction: transaction);
+            return connection.QueryAsync<TEntity>(sql, transaction: transaction, commandTimeout: commandTimeout);
         }
 
         private static string BuildPagedQuery(IDbConnection connection, Type type, int pageNumber, int pageSize)

--- a/src/Dommel/DommelMapper.SqlServerSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqlServerSqlBuilder.cs
@@ -27,7 +27,7 @@ namespace Dommel
             }
 
             /// <inheritdoc/>
-            public string QuoteIdentifier(string identifier) => identifier;
+            public string QuoteIdentifier(string identifier) => $"[{identifier}]";
         }
     }
 }

--- a/test/Dommel.Tests/LikeTests.cs
+++ b/test/Dommel.Tests/LikeTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
-using Moq;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 using Xunit;
 using static Dommel.DommelMapper;
 
@@ -19,7 +17,7 @@ namespace Dommel.Tests
             var sql = expression.ToSql(out var dynamicParameters);
 
             // Assert
-            Assert.Equal("where Bar like @p1", sql.Trim());
+            Assert.Equal("where [Bar] like @p1", sql.Trim());
             Assert.Single(dynamicParameters.ParameterNames);
             Assert.Equal("%test%", dynamicParameters.Get<string>("p1"));
         }
@@ -35,7 +33,7 @@ namespace Dommel.Tests
             var sql = expression.ToSql(out var dynamicParameters);
 
             // Assert
-            Assert.Equal("where Bar like @p1", sql.Trim());
+            Assert.Equal("where [Bar] like @p1", sql.Trim());
             Assert.Single(dynamicParameters.ParameterNames);
             Assert.Equal("test%", dynamicParameters.Get<string>("p1"));
         }
@@ -51,7 +49,7 @@ namespace Dommel.Tests
             var sql = expression.ToSql(out var dynamicParameters);
 
             // Assert
-            Assert.Equal("where Bar like @p1", sql.Trim());
+            Assert.Equal("where [Bar] like @p1", sql.Trim());
             Assert.Single(dynamicParameters.ParameterNames);
             Assert.Equal("%test", dynamicParameters.Get<string>("p1"));
         }

--- a/test/Dommel.Tests/LoggingTests.cs
+++ b/test/Dommel.Tests/LoggingTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Data;
-using Dapper;
+﻿using Dapper;
 using Moq;
 using Moq.Dapper;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Data;
 using Xunit;
 
 namespace Dommel.Tests
@@ -29,7 +29,7 @@ namespace Dommel.Tests
 
             // Assert
             Assert.Single(logs);
-            Assert.Equal("Get<Foo>: select * from Foos where Id = @Id", logs[0]);
+            Assert.Equal("Get<Foo>: select * from [Foos] where [Id] = @Id", logs[0]);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Dommel.Tests
 
             // Assert
             Assert.Single(logs);
-            Assert.Equal("Get<Bar>: select * from Bars where Id = @Id0 and KeyColumn2 = @Id1 and KeyColumn3 = @Id2", logs[0]);
+            Assert.Equal("Get<Bar>: select * from [Bars] where [Id] = @Id0 and [KeyColumn2] = @Id1 and [KeyColumn3] = @Id2", logs[0]);
         }
 
         [Fact]
@@ -72,8 +72,8 @@ namespace Dommel.Tests
 
             // Assert
             Assert.Equal(2, logs.Count);
-            Assert.Equal("Get<Foo>: select * from Foos where Id = @Id", logs[0]);
-            Assert.Equal("Get<Foo>: select * from Foos where Id = @Id", logs[1]);
+            Assert.Equal("Get<Foo>: select * from [Foos] where [Id] = @Id", logs[0]);
+            Assert.Equal("Get<Foo>: select * from [Foos] where [Id] = @Id", logs[1]);
         }
 
         [Fact]

--- a/test/Dommel.Tests/ProjectTests.cs
+++ b/test/Dommel.Tests/ProjectTests.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Dapper;
+using Moq;
+using Moq.Dapper;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using Dapper;
-using Moq;
-using Moq.Dapper;
 using Xunit;
 
 namespace Dommel.Tests
@@ -17,7 +17,7 @@ namespace Dommel.Tests
         {
             // Arrange
             var queries = new List<string>();
-            var expectedQuery = "Project<ProjectedFoo>: select Id, Name, DateUpdated from ProjectedFoos where Id = @Id";
+            var expectedQuery = "Project<ProjectedFoo>: select [Id], [Name], [DateUpdated] from [ProjectedFoos] where [Id] = @Id";
             var mock = new Mock<IDbConnection>();
             mock.SetupDapper(x => x.QueryFirstOrDefault<ProjectedFoo>(It.Is<string>(s => s == expectedQuery), It.IsAny<object>(), null, null, null))
                 .Returns(new ProjectedFoo())
@@ -40,7 +40,7 @@ namespace Dommel.Tests
         {
             // Arrange
             var queries = new List<string>();
-            var expectedQuery = "ProjectAll<ProjectedFoo>: select Id, Name, DateUpdated from ProjectedFoos";
+            var expectedQuery = "ProjectAll<ProjectedFoo>: select [Id], [Name], [DateUpdated] from [ProjectedFoos]";
             var mock = new Mock<IDbConnection>();
             mock.SetupDapper(x => x.Query<ProjectedFoo>(It.Is<string>(s => s == expectedQuery), It.IsAny<object>(), null, true, null, null))
                 .Returns(new[] { new ProjectedFoo() })
@@ -63,7 +63,7 @@ namespace Dommel.Tests
         {
             // Arrange
             var queries = new List<string>();
-            var expectedQuery = "ProjectPaged<ProjectedFoo>: select Id, Name, DateUpdated from ProjectedFoos order by Id offset 0 rows fetch next 5 rows only"; ;
+            var expectedQuery = "ProjectPaged<ProjectedFoo>: select [Id], [Name], [DateUpdated] from [ProjectedFoos] order by [Id] offset 0 rows fetch next 5 rows only"; ;
             var mock = new Mock<IDbConnection>();
             mock.SetupDapper(x => x.Query<ProjectedFoo>(It.Is<string>(s => s == expectedQuery), It.IsAny<object>(), null, true, null, null))
                 .Returns(new[] { new ProjectedFoo() })

--- a/test/Dommel.Tests/SupportDynamicExpressions.cs
+++ b/test/Dommel.Tests/SupportDynamicExpressions.cs
@@ -2,12 +2,10 @@
 using Moq;
 using Moq.Dapper;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using Xunit;
 using static Dommel.DommelMapper;
 
@@ -30,7 +28,7 @@ namespace Dommel.Tests
             var dommelExpression = sqlExpression.Where(p => p.Id == 1 && p.Bar.Contains("test"));
             var sql = dommelExpression.ToSql(out var dynamicParameters);
 
-            Assert.Equal("where Id = @p1 and Bar like @p2", sql.Trim());
+            Assert.Equal("where [Id] = @p1 and [Bar] like @p2", sql.Trim());
             Assert.Equal(1, dynamicParameters.Get<int>("p1"));
             Assert.Equal("%test%", dynamicParameters.Get<string>("p2"));
         }
@@ -44,7 +42,7 @@ namespace Dommel.Tests
             var dommelExpression = sqlExpression.Where(expression);
             var sql = dommelExpression.ToSql(out var dynamicParameters);
 
-            Assert.Equal("where Id = @p1 and Bar like @p2", sql.Trim());
+            Assert.Equal("where [Id] = @p1 and [Bar] like @p2", sql.Trim());
             Assert.Equal(1, dynamicParameters.Get<int>("p1"));
             Assert.Equal("%test%", dynamicParameters.Get<string>("p2"));
         }
@@ -55,7 +53,7 @@ namespace Dommel.Tests
             var dommelExpression = sqlExpression.Where(p => p.Id == 1 || p.Bar.Contains("testOr"));
             var sql = dommelExpression.ToSql(out var dynamicParameters);
 
-            Assert.Equal("where Id = @p1 or Bar like @p2", sql.Trim());
+            Assert.Equal("where [Id] = @p1 or [Bar] like @p2", sql.Trim());
             Assert.Equal(1, dynamicParameters.Get<int>("p1"));
             Assert.Equal("%testOr%", dynamicParameters.Get<string>("p2"));
         }
@@ -69,7 +67,7 @@ namespace Dommel.Tests
             var dommelExpression = sqlExpression.Where(expression);
             var sql = dommelExpression.ToSql(out var dynamicParameters);
 
-            Assert.Equal("where Id = @p1 or Id = @p2", sql.Trim());
+            Assert.Equal("where [Id] = @p1 or [Id] = @p2", sql.Trim());
             Assert.Equal(1, dynamicParameters.Get<int>("p1"));
             Assert.Equal(2, dynamicParameters.Get<int>("p2"));
         }


### PR DESCRIPTION
Surround table and column names with open and close square brackets for SQL Server so that using reserved words as table and/or column names will not throw exceptions.