### PR TITLE
Key and Identity properties are independent of each other.

### DIFF
--- a/src/Dommel/Attributes/IdentityAttribute.cs
+++ b/src/Dommel/Attributes/IdentityAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Dommel.Attributes
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Denotes one or more properties that auto-generate/assign value.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class IdentityAttribute : Attribute
+    {
+        
+    }
+}

--- a/src/Dommel/Dommel.csproj
+++ b/src/Dommel/Dommel.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Dommel/Dommel.csproj
+++ b/src/Dommel/Dommel.csproj
@@ -16,9 +16,10 @@
     <RepositoryUrl>https://github.com/henkmollema/Dommel</RepositoryUrl>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
+    <Version>2.0.0-beta3.2</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="Dapper" Version="1.50.7" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />

--- a/src/Dommel/DommelMapper.DefaultIdentityPropertyResolver.cs
+++ b/src/Dommel/DommelMapper.DefaultIdentityPropertyResolver.cs
@@ -1,0 +1,33 @@
+﻿using Dommel.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Dommel
+{
+    public static partial class DommelMapper
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// Implements the <see cref="T:Dommel.DommelMapper.IIdentityPropertyResolver" /> interface by resolving identity properties
+        /// with the [Identity] attribute or with the name 'Id'.
+        /// </summary>
+        public class DefaultIdentityPropertyResolver : IIdentityPropertyResolver
+        {
+            /// <inheritdoc />
+            /// <summary>
+            /// Finds the identity properties by looking for properties with the [Identity] attribute.
+            /// </summary>
+            public virtual IEnumerable<PropertyInfo> ResolveIdentityProperties(Type type)
+            {
+                var identityProps = Resolvers
+                    .Properties(type)
+                    .Where(p => p.GetCustomAttribute<IdentityAttribute>() != null)
+                    .ToArray();
+
+                return identityProps;
+            }
+        }
+    }
+}

--- a/src/Dommel/DommelMapper.DefaultKeyPropertyResolver.cs
+++ b/src/Dommel/DommelMapper.DefaultKeyPropertyResolver.cs
@@ -1,28 +1,25 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
-using Dapper;
 
 namespace Dommel
 {
     public static partial class DommelMapper
     {
+        /// <inheritdoc />
         /// <summary>
-        /// Implements the <see cref="IKeyPropertyResolver"/> interface by resolving key properties
+        /// Implements the <see cref="T:Dommel.DommelMapper.IKeyPropertyResolver" /> interface by resolving key properties
         /// with the [Key] attribute or with the name 'Id'.
         /// </summary>
         public class DefaultKeyPropertyResolver : IKeyPropertyResolver
         {
+            /// <inheritdoc />
             /// <summary>
             /// Finds the key properties by looking for properties with the [Key] attribute.
             /// </summary>
-            public PropertyInfo[] ResolveKeyProperties(Type type) => ResolveKeyProperties(type, out _);
-
-            /// <summary>
-            /// Finds the key properties by looking for properties with the [Key] attribute.
-            /// </summary>
-            public PropertyInfo[] ResolveKeyProperties(Type type, out bool isIdentity)
+            public virtual IEnumerable<PropertyInfo> ResolveKeyProperties(Type type)
             {
                 var keyProps = Resolvers
                         .Properties(type)
@@ -34,7 +31,6 @@ namespace Dommel
                     throw new InvalidOperationException($"Could not find the key properties for type '{type.FullName}'.");
                 }
 
-                isIdentity = true;
                 return keyProps;
             }
         }

--- a/src/Dommel/DommelMapper.IIdentityPropertyResolver.cs
+++ b/src/Dommel/DommelMapper.IIdentityPropertyResolver.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Dommel
+{
+    public static partial class DommelMapper
+    {
+        /// <summary>
+        /// Defines methods for resolving the identity property of entities.
+        /// Identity refers to the behaviour that property being assigned an auto-generating number in the data source which could also be achieved using Sequence (SQL Server),
+        /// not necessarily an Identity column itself.
+        /// Custom implementations can be registerd with <see cref="DommelMapper.SetIdentityPropertyResolver(IIdentityPropertyResolver)"/>.
+        /// </summary>
+        public interface IIdentityPropertyResolver
+        {
+            /// <summary>
+            /// Resolves the identity properties for the specified type.
+            /// </summary>
+            /// <param name="type">The type to resolve the identity properties for.</param>
+            /// <returns>A collection of <see cref="PropertyInfo"/> instances of the identity properties of <paramref name="type"/>.</returns>
+            IEnumerable<PropertyInfo> ResolveIdentityProperties(Type type);
+        }
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="DommelMapper.IIdentityPropertyResolver"/>.
+    /// </summary>
+    public static class IdentityPropertyResolverExtensions
+    {
+        /// <summary>
+        /// Resolves the single identity property for the specified type.
+        /// </summary>
+        /// <param name="identityPropertyResolver">The <see cref="DommelMapper.IIdentityPropertyResolver"/>.</param>
+        /// <param name="type">The type to resolve the identity property for.</param>
+        /// <returns>A <see cref="PropertyInfo"/> instance of the identity property of <paramref name="type"/>.</returns>
+        public static PropertyInfo ResolveIdentityProperty(this DommelMapper.IIdentityPropertyResolver identityPropertyResolver, Type type)
+            => identityPropertyResolver.ResolveIdentityProperties(type).FirstOrDefault();
+    }
+}

--- a/src/Dommel/DommelMapper.IKeyPropertyResolver.cs
+++ b/src/Dommel/DommelMapper.IKeyPropertyResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using static Dommel.DommelMapper;
@@ -9,7 +10,7 @@ namespace Dommel
     {
         /// <summary>
         /// Defines methods for resolving the key property of entities.
-        /// Custom implementations can be registerd with <see cref="SetKeyPropertyResolver(IKeyPropertyResolver)"/>.
+        /// Custom implementations can be registerd with <see cref="DommelMapper.SetKeyPropertyResolver(IKeyPropertyResolver)"/>.
         /// </summary>
         public interface IKeyPropertyResolver
         {
@@ -18,15 +19,7 @@ namespace Dommel
             /// </summary>
             /// <param name="type">The type to resolve the key properties for.</param>
             /// <returns>A collection of <see cref="PropertyInfo"/> instances of the key properties of <paramref name="type"/>.</returns>
-            PropertyInfo[] ResolveKeyProperties(Type type);
-
-            /// <summary>
-            /// Resolves the key properties for the specified type.
-            /// </summary>
-            /// <param name="type">The type to resolve the key properties for.</param>
-            /// <param name="isIdentity">Indicates whether the key properties are identity properties.</param>
-            /// <returns>A collection of <see cref="PropertyInfo"/> instances of the key properties of <paramref name="type"/>.</returns>
-            PropertyInfo[] ResolveKeyProperties(Type type, out bool isIdentity);
+            IEnumerable<PropertyInfo> ResolveKeyProperties(Type type);
         }
     }
 
@@ -43,15 +36,5 @@ namespace Dommel
         /// <returns>A <see cref="PropertyInfo"/> instance of the key property of <paramref name="type"/>.</returns>
         public static PropertyInfo ResolveKeyProperty(this IKeyPropertyResolver keyPropertyResolver, Type type)
             => keyPropertyResolver.ResolveKeyProperties(type).FirstOrDefault();
-
-        /// <summary>
-        /// Resolves the single key property for the specified type.
-        /// </summary>
-        /// <param name="keyPropertyResolver">The <see cref="IKeyPropertyResolver"/>.</param>
-        /// <param name="type">The type to resolve the key property for.</param>
-        /// <param name="isIdentity">Indicates whether the key properties are identity properties.</param>
-        /// <returns>A <see cref="PropertyInfo"/> instance of the key property of <paramref name="type"/>.</returns>
-        public static PropertyInfo ResolveKeyProperty(this IKeyPropertyResolver keyPropertyResolver, Type type, out bool isIdentity) =>
-            keyPropertyResolver.ResolveKeyProperties(type, out isIdentity).FirstOrDefault();
     }
 }

--- a/src/Dommel/DommelMapper.Insert.cs
+++ b/src/Dommel/DommelMapper.Insert.cs
@@ -76,6 +76,7 @@ namespace Dommel
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
                 var tableName = Resolvers.Table(type, connection);
+                var keyProperties = Resolvers.KeyProperties(type);
                 var identityProperties = Resolvers.IdentityProperties(type).ToArray();
 
                 var typeProperties = new List<PropertyInfo>();
@@ -94,10 +95,10 @@ namespace Dommel
                 }
 
                 var columnNames = typeProperties.Select(p => Resolvers.Column(p, connection)).ToArray();
-                var paramNames = typeProperties.Select(p => "@" + p.Name).ToArray();
+                var paramNames = typeProperties.Select(p => $"@{p.Name}").ToArray();
 
                 var builder = GetSqlBuilder(connection);
-                sql = builder.BuildInsert(tableName, columnNames, paramNames, identityProperties);
+                sql = builder.BuildInsert(tableName, columnNames, paramNames, keyProperties, identityProperties);
 
                 QueryCache.TryAdd(cacheKey, sql);
             }

--- a/src/Dommel/DommelMapper.MySqlSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.MySqlSqlBuilder.cs
@@ -12,7 +12,7 @@ namespace Dommel
         {
             /// <inheritdoc/>
             public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
-                IEnumerable<PropertyInfo> identityProperties) =>
+                IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties) =>
                 $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select LAST_INSERT_ID() id";
 
             /// <inheritdoc/>

--- a/src/Dommel/DommelMapper.MySqlSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.MySqlSqlBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 
 namespace Dommel
 {
@@ -10,7 +11,8 @@ namespace Dommel
         public class MySqlSqlBuilder : ISqlBuilder
         {
             /// <inheritdoc/>
-            public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty) =>
+            public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
+                IEnumerable<PropertyInfo> identityProperties) =>
                 $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select LAST_INSERT_ID() id";
 
             /// <inheritdoc/>

--- a/src/Dommel/DommelMapper.PostgresSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.PostgresSqlBuilder.cs
@@ -13,7 +13,7 @@ namespace Dommel
         {
             /// <inheritdoc/>
             public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
-                IEnumerable<PropertyInfo> identityProperties)
+                IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties)
             {
                 var sql = $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)})";
 

--- a/src/Dommel/DommelMapper.SqlBuilders.cs
+++ b/src/Dommel/DommelMapper.SqlBuilders.cs
@@ -58,12 +58,10 @@ namespace Dommel
             /// <param name="tableName">The name of the table to query.</param>
             /// <param name="columnNames">The names of the columns in the table.</param>
             /// <param name="paramNames">The names of the parameters in the database command.</param>
-            /// <param name="identityProperties">
-            ///     The key property. This can be used to query a specific column for the new id. This is
-            ///     optional.
-            /// </param>
+            /// <param name="keyProperties">The key properties. This can be used to return the newly inserted record by querying its Primary Keys. This is optional.</param>
+            /// <param name="identityProperties">The identity properties. This can be used to return values of columns that are auto-generated. This is optional.</param>
             /// <returns>An insert query including a query to fetch the new id.</returns>
-            string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> identityProperties);
+            string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties);
 
             /// <summary>
             /// Builds the paging part to be appended to an existing select query.

--- a/src/Dommel/DommelMapper.SqlBuilders.cs
+++ b/src/Dommel/DommelMapper.SqlBuilders.cs
@@ -58,12 +58,12 @@ namespace Dommel
             /// <param name="tableName">The name of the table to query.</param>
             /// <param name="columnNames">The names of the columns in the table.</param>
             /// <param name="paramNames">The names of the parameters in the database command.</param>
-            /// <param name="keyProperty">
-            /// The key property. This can be used to query a specific column for the new id. This is
-            /// optional.
+            /// <param name="identityProperties">
+            ///     The key property. This can be used to query a specific column for the new id. This is
+            ///     optional.
             /// </param>
             /// <returns>An insert query including a query to fetch the new id.</returns>
-            string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty);
+            string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> identityProperties);
 
             /// <summary>
             /// Builds the paging part to be appended to an existing select query.

--- a/src/Dommel/DommelMapper.SqlServerCeSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqlServerCeSqlBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 
 namespace Dommel
 {
@@ -10,7 +11,8 @@ namespace Dommel
         public class SqlServerCeSqlBuilder : ISqlBuilder
         {
             /// <inheritdoc/>
-            public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty) =>
+            public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
+                IEnumerable<PropertyInfo> identityProperties) =>
                 $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select @@IDENTITY";
 
             /// <inheritdoc/>

--- a/src/Dommel/DommelMapper.SqlServerCeSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqlServerCeSqlBuilder.cs
@@ -12,7 +12,7 @@ namespace Dommel
         {
             /// <inheritdoc/>
             public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
-                IEnumerable<PropertyInfo> identityProperties) =>
+                IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties) =>
                 $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select @@IDENTITY";
 
             /// <inheritdoc/>

--- a/src/Dommel/DommelMapper.SqlServerSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqlServerSqlBuilder.cs
@@ -13,7 +13,7 @@ namespace Dommel
         {
             /// <inheritdoc/>
             public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
-                IEnumerable<PropertyInfo> identityProperties)
+                IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties)
             {
                 var outputClause = "";
                 if (identityProperties != null)

--- a/src/Dommel/DommelMapper.SqlServerSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqlServerSqlBuilder.cs
@@ -30,7 +30,7 @@ namespace Dommel
                     }
                 }
 
-                return $"set nocount on insert into {tableName} ({string.Join(", ", columnNames)}){outputClause} values ({string.Join(", ", paramNames)})";
+                return $"insert into {tableName} ({string.Join(", ", columnNames)}){outputClause} values ({string.Join(", ", paramNames)})";
             }
                 
 

--- a/src/Dommel/DommelMapper.SqliteSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqliteSqlBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 
 namespace Dommel
 {
@@ -10,7 +11,8 @@ namespace Dommel
         public class SqliteSqlBuilder : ISqlBuilder
         {
             /// <inheritdoc/>
-            public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty)
+            public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
+                IEnumerable<PropertyInfo> identityProperties)
             {
                 return $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select last_insert_rowid() id";
             }

--- a/src/Dommel/DommelMapper.SqliteSqlBuilder.cs
+++ b/src/Dommel/DommelMapper.SqliteSqlBuilder.cs
@@ -12,11 +12,9 @@ namespace Dommel
         {
             /// <inheritdoc/>
             public virtual string BuildInsert(string tableName, string[] columnNames, string[] paramNames,
-                IEnumerable<PropertyInfo> identityProperties)
-            {
-                return $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select last_insert_rowid() id";
-            }
-
+                IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties) =>
+                $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select last_insert_rowid() id";
+            
             /// <inheritdoc/>
             public virtual string BuildPaging(string orderBy, int pageNumber, int pageSize)
             {

--- a/src/Dommel/DommelMapper.Update.cs
+++ b/src/Dommel/DommelMapper.Update.cs
@@ -48,11 +48,13 @@ namespace Dommel
             {
                 var tableName = Resolvers.Table(type, connection);
                 var keyProperties = Resolvers.KeyProperties(type);
+                var identityProperties = Resolvers.IdentityProperties(type);
                 var builder = GetSqlBuilder(connection);
 
-                // Use all properties which are settable.
+                // Use all properties which are settable except key and identity properties.
                 var typeProperties = Resolvers.Properties(type)
                                               .Except(keyProperties)
+                                              .Except(identityProperties)
                                               .Where(p => p.GetSetMethod() != null)
                                               .ToArray();
 

--- a/test/Dommel.IntegrationTests/Dommel.IntegrationTests.csproj
+++ b/test/Dommel.IntegrationTests/Dommel.IntegrationTests.csproj
@@ -5,8 +5,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="mysqlconnector" Version="0.47.1" />
-    <PackageReference Include="Npgsql" Version="4.0.3" />
+    <PackageReference Include="mysqlconnector" Version="0.49.3" />
+    <PackageReference Include="Npgsql" Version="4.0.4" />
     <ProjectReference Include="..\..\src\Dommel\Dommel.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Dommel.IntegrationTests/InsertGuidTests.cs
+++ b/test/Dommel.IntegrationTests/InsertGuidTests.cs
@@ -19,7 +19,7 @@ namespace Dommel.IntegrationTests
 
         public class GuidSqlServerSqlBuilder : DommelMapper.SqlServerSqlBuilder
         {
-            public override string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> identityProperties) =>
+            public override string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties) =>
                 $"set nocount on insert into {tableName} ({string.Join(", ", columnNames)}) output inserted.Id values ({string.Join(", ", paramNames)})";
         }
 

--- a/test/Dommel.IntegrationTests/InsertGuidTests.cs
+++ b/test/Dommel.IntegrationTests/InsertGuidTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿using Dapper;
+using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Reflection;
-using Dapper;
 using Xunit;
 
 namespace Dommel.IntegrationTests
@@ -18,7 +19,7 @@ namespace Dommel.IntegrationTests
 
         public class GuidSqlServerSqlBuilder : DommelMapper.SqlServerSqlBuilder
         {
-            public override string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty) =>
+            public override string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> identityProperties) =>
                 $"set nocount on insert into {tableName} ({string.Join(", ", columnNames)}) output inserted.Id values ({string.Join(", ", paramNames)})";
         }
 

--- a/test/Dommel.IntegrationTests/Models.cs
+++ b/test/Dommel.IntegrationTests/Models.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dommel.Attributes;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -6,6 +7,7 @@ namespace Dommel.IntegrationTests
 {
     public class Product
     {
+        [Identity]
         public int Id { get; set; }
 
         public string Name { get; set; }
@@ -19,6 +21,7 @@ namespace Dommel.IntegrationTests
 
     public class Category
     {
+        [Identity]
         public int Id { get; set; }
 
         public string Name { get; set; }
@@ -26,6 +29,7 @@ namespace Dommel.IntegrationTests
 
     public class Order
     {
+        [Identity]
         public int Id { get; set; }
 
         public DateTime Created { get; set; } = DateTime.UtcNow;
@@ -36,6 +40,7 @@ namespace Dommel.IntegrationTests
 
     public class OrderLine
     {
+        [Identity]
         public int Id { get; set; }
 
         public int OrderId { get; set; }
@@ -45,6 +50,7 @@ namespace Dommel.IntegrationTests
 
     public class Foo
     {
+        [Identity]
         public int Id { get; set; }
 
         public string Name { get; set; } = nameof(Foo);
@@ -52,6 +58,7 @@ namespace Dommel.IntegrationTests
 
     public class Bar
     {
+        [Identity]
         public int Id { get; set; }
 
         public string Name { get; set; } = nameof(Bar);

--- a/test/Dommel.Tests/DefaultKeyPropertyResolverTests.cs
+++ b/test/Dommel.Tests/DefaultKeyPropertyResolverTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Xunit;
 
 namespace Dommel.Tests
@@ -11,7 +12,7 @@ namespace Dommel.Tests
         [Fact]
         public void MapsIdProperty()
         {
-            var prop = Resolver.ResolveKeyProperties(typeof(Foo))[0];
+            var prop = Resolver.ResolveKeyProperties(typeof(Foo)).First();
             Assert.Equal(typeof(Foo).GetProperty("Id"), prop);
         }
 
@@ -35,21 +36,21 @@ namespace Dommel.Tests
         [Fact]
         public void MapsWithAttribute()
         {
-            var prop = Resolver.ResolveKeyProperties(typeof(Bar))[0];
+            var prop = Resolver.ResolveKeyProperties(typeof(Bar)).First();
             Assert.Equal(typeof(Bar).GetProperty("BarId"), prop);
         }
 
         [Fact]
         public void NoKeyProperties_ThrowsException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => Resolver.ResolveKeyProperties(typeof(Nope))[0]);
+            var ex = Assert.Throws<InvalidOperationException>(() => Resolver.ResolveKeyProperties(typeof(Nope)).First());
             Assert.Equal($"Could not find the key properties for type '{typeof(Nope).FullName}'.", ex.Message);
         }
 
         [Fact]
         public void MapsMultipleKeyProperties()
         {
-            var keyProperties = Resolver.ResolveKeyProperties(typeof(FooBar));
+            var keyProperties = Resolver.ResolveKeyProperties(typeof(FooBar)).ToArray();
             Assert.Equal(typeof(FooBar).GetProperty("Id"), keyProperties[0]);
             Assert.Equal(typeof(FooBar).GetProperty("BarId"), keyProperties[1]);
         }

--- a/test/Dommel.Tests/Dommel.Tests.csproj
+++ b/test/Dommel.Tests/Dommel.Tests.csproj
@@ -6,8 +6,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dommel\Dommel.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="Moq.Dapper" Version="1.0.0.7" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Moq.Dapper" Version="1.0.0.9" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/test/Dommel.Tests/ParameterPrefixTest.cs
+++ b/test/Dommel.Tests/ParameterPrefixTest.cs
@@ -113,7 +113,7 @@ namespace Dommel.Tests
             public string QuoteIdentifier(string identifier) => identifier;
 
             /// <inheritdoc/>
-            public string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> identityProperties)
+            public string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> keyProperties, IEnumerable<PropertyInfo> identityProperties)
             {
                 return $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select last_insert_rowid() id";
             }

--- a/test/Dommel.Tests/ParameterPrefixTest.cs
+++ b/test/Dommel.Tests/ParameterPrefixTest.cs
@@ -1,16 +1,13 @@
 ﻿using Dapper;
 using Moq;
 using Moq.Dapper;
-using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data;
 using System.Reflection;
-using System.Text;
 using Xunit;
 using static Dommel.DommelMapper;
-using System.Data.SqlClient;
-using System.ComponentModel.DataAnnotations;
 
 namespace Dommel.Tests
 {
@@ -116,7 +113,7 @@ namespace Dommel.Tests
             public string QuoteIdentifier(string identifier) => identifier;
 
             /// <inheritdoc/>
-            public string BuildInsert(string tableName, string[] columnNames, string[] paramNames, PropertyInfo keyProperty)
+            public string BuildInsert(string tableName, string[] columnNames, string[] paramNames, IEnumerable<PropertyInfo> identityProperties)
             {
                 return $"insert into {tableName} ({string.Join(", ", columnNames)}) values ({string.Join(", ", paramNames)}); select last_insert_rowid() id";
             }


### PR DESCRIPTION
Identity is now an independent concept.

Entity:

```
public class Product
{
    [Key]
    [Identity] // new attribute
    public int Id { get; set; }

    public string Name { get; set; }

    [Identity] // new attribute
    public int SerialNumber { get; set; } // in the database, this column is auto-generated using a Sequence
}
```

Usage:

```
var entity = new Product
{
    Name = "Test"
};
var results = await connection.InsertAsync(entity).ConfigureAwait(false);
```

The resulting INSERT statement for SQL Server
```
SET NOCOUNT ON INSERT INTO [Product] ([Name]) OUTPUT Inserted.[Id], Inserted.[SerialNumber] VALUES (@Name)
```

The variable `results` would then be assigned with a `SqlMapper.DapperRow` which is essentially a `IDictionary<string, object>`. `results` would contain all the identity columns and their value. It would look something like
```
{
    "Id": 11,
    "SerialNumber": 100
}
```

If the Entity has only one Identity property, `results` is assigned the value of the identity instead. Using the example `Product` entity above, assuming that `SerialNumber` was not an Identity, `results` would then be the integer `11`.