### PR TITLE
Add [Ignore] attribute support

### DIFF
--- a/src/Dommel/DommelMapper.DefaultPropertyResolver.cs
+++ b/src/Dommel/DommelMapper.DefaultPropertyResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Dommel
@@ -30,7 +31,8 @@ namespace Dommel
             /// </summary>
             /// <param name="type">The type to resolve the properties to be mapped for.</param>
             /// <returns>A collection of <see cref="PropertyInfo"/>'s of the <paramref name="type"/>.</returns>
-            public virtual IEnumerable<PropertyInfo> ResolveProperties(Type type) => FilterComplexTypes(type.GetRuntimeProperties());
+            public virtual IEnumerable<PropertyInfo> ResolveProperties(Type type) =>
+                FilterComplexTypes(type.GetRuntimeProperties()).Where(p => !p.IsDefined(typeof(IgnoreAttribute)));
 
             /// <summary>
             /// Gets a collection of types that are considered 'primitive' for Dommel but are not for the CLR.
@@ -49,7 +51,6 @@ namespace Dommel
                 {
                     var type = property.PropertyType;
                     type = Nullable.GetUnderlyingType(type) ?? type;
-
                     if (type.GetTypeInfo().IsPrimitive || type.GetTypeInfo().IsEnum || PrimitiveTypes.Contains(type))
                     {
                         yield return property;
@@ -57,5 +58,13 @@ namespace Dommel
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Specifies that a property should be ignored.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class IgnoreAttribute : Attribute
+    {
     }
 }

--- a/test/Dommel.Tests/DefaultPropertyResolverTests.cs
+++ b/test/Dommel.Tests/DefaultPropertyResolverTests.cs
@@ -10,19 +10,44 @@ namespace Dommel.Tests
         [Fact]
         public void ResolvesSimpleProperties()
         {
+            // Arrange
             var resolver = new DommelMapper.DefaultPropertyResolver();
             var type = typeof(Foo);
+
+            // Act
             var props = resolver.ResolveProperties(type).ToArray();
+
+            // Assert
             Assert.Equal(type.GetProperties().Skip(1).ToArray(), props);
         }
 
         [Fact]
         public void Resolves_WithCustom()
         {
+            // Arrange
             var resolver = new CustomResolver();
             var type = typeof(Foo);
+
+            // Act
             var props = resolver.ResolveProperties(type).ToArray();
+
+            // Assert
             Assert.Equal(type.GetProperties().Skip(2).ToArray(), props);
+        }
+
+        [Fact]
+        public void IgnoresIgnoreAttribute()
+        {
+            // Arrange
+            var resolver = new DommelMapper.DefaultPropertyResolver();
+            var type = typeof(Bar);
+
+            // Act
+            var props = resolver.ResolveProperties(type).ToArray();
+
+            // Assert
+            var prop = Assert.Single(props);
+            Assert.Equal(type.GetProperty("Id"), prop);
         }
 
         private class CustomResolver : DommelMapper.DefaultPropertyResolver
@@ -58,17 +83,12 @@ namespace Dommel.Tests
             public byte[] Bytes { get; set; }
         }
 
-        /*
-            typeof(object),
-            typeof(string),
-            typeof(Guid),
-            typeof(decimal),
-            typeof(double),
-            typeof(float),
-            typeof(DateTime),
-            typeof(DateTimeOffset),
-            typeof(TimeSpan),
-            typeof(byte[])
-         */
+        private class Bar
+        {
+            public int Id { get; set; }
+
+            [Ignore]
+            public DateTime Timestamp { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Allow ignoring properties by specifying the `[Ignore]` attribute. Ignored properties are not used for insert and update queries but are mapped when selecting data.

Fixes #122 