### PR TITLE
Change DeleteMultiple and DeleteAll return type

### DIFF
--- a/src/Dommel/Delete.cs
+++ b/src/Dommel/Delete.cs
@@ -60,34 +60,34 @@ namespace Dommel
 
         /// <summary>
         /// Deletes all entities of type <typeparamref name="TEntity"/> matching the specified predicate from the database.
-        /// Returns a value indicating whether the operation succeeded.
+        /// Returns the number of rows affected.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="predicate">A predicate to filter which entities are deleted.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
-        /// <returns>A value indicating whether the delete operation succeeded.</returns>
-        public static bool DeleteMultiple<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, IDbTransaction? transaction = null)
+        /// <returns>The number of rows affected.</returns>
+        public static int DeleteMultiple<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, IDbTransaction? transaction = null)
         {
             var sql = BuildDeleteMultipleQuery(GetSqlBuilder(connection), predicate, out var parameters);
             LogQuery<TEntity>(sql);
-            return connection.Execute(sql, parameters, transaction) > 0;
+            return connection.Execute(sql, parameters, transaction);
         }
 
         /// <summary>
         /// Deletes all entities of type <typeparamref name="TEntity"/> matching the specified predicate from the database.
-        /// Returns a value indicating whether the operation succeeded.
+        /// Returns the number of rows affected.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="predicate">A predicate to filter which entities are deleted.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
-        /// <returns>A value indicating whether the delete operation succeeded.</returns>
-        public static async Task<bool> DeleteMultipleAsync<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, IDbTransaction? transaction = null)
+        /// <returns>The number of rows affected.</returns>
+        public static async Task<int> DeleteMultipleAsync<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, IDbTransaction? transaction = null)
         {
             var sql = BuildDeleteMultipleQuery(GetSqlBuilder(connection), predicate, out var parameters);
             LogQuery<TEntity>(sql);
-            return await connection.ExecuteAsync(sql, parameters, transaction) > 0;
+            return await connection.ExecuteAsync(sql, parameters, transaction);
         }
 
         private static string BuildDeleteMultipleQuery<TEntity>(ISqlBuilder sqlBuilder, Expression<Func<TEntity, bool>> predicate, out DynamicParameters parameters)
@@ -105,32 +105,32 @@ namespace Dommel
 
         /// <summary>
         /// Deletes all entities of type <typeparamref name="TEntity"/> from the database.
-        /// Returns a value indicating whether the operation succeeded.
+        /// Returns the number of rows affected.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
-        /// <returns>A value indicating whether the delete operation succeeded.</returns>
-        public static bool DeleteAll<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null)
+        /// <returns>The number of rows affected.</returns>
+        public static int DeleteAll<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null)
         {
             var sql = BuildDeleteAllQuery(GetSqlBuilder(connection), typeof(TEntity));
             LogQuery<TEntity>(sql);
-            return connection.Execute(sql, transaction: transaction) > 0;
+            return connection.Execute(sql, transaction: transaction);
         }
 
         /// <summary>
         /// Deletes all entities of type <typeparamref name="TEntity"/> from the database.
-        /// Returns a value indicating whether the operation succeeded.
+        /// Returns the number of rows affected.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
-        /// <returns>A value indicating whether the delete operation succeeded.</returns>
-        public static async Task<bool> DeleteAllAsync<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null)
+        /// <returns>The number of rows affected.</returns>
+        public static async Task<int> DeleteAllAsync<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null)
         {
             var sql = BuildDeleteAllQuery(GetSqlBuilder(connection), typeof(TEntity));
             LogQuery<TEntity>(sql);
-            return await connection.ExecuteAsync(sql, transaction: transaction) > 0;
+            return await connection.ExecuteAsync(sql, transaction: transaction);
         }
 
         internal static string BuildDeleteAllQuery(ISqlBuilder sqlBuilder, Type type)

--- a/test/Dommel.IntegrationTests/DeleteTests.cs
+++ b/test/Dommel.IntegrationTests/DeleteTests.cs
@@ -44,7 +44,7 @@ namespace Dommel.IntegrationTests
         public void DeleteAll(DatabaseDriver database)
         {
             using var con = database.GetConnection();
-            Assert.True(con.DeleteAll<Foo>());
+            Assert.True(con.DeleteAll<Foo>() > 0);
             Assert.Empty(con.GetAll<Foo>());
         }
 
@@ -53,7 +53,7 @@ namespace Dommel.IntegrationTests
         public async Task DeleteAllAsync(DatabaseDriver database)
         {
             using var con = database.GetConnection();
-            Assert.True(await con.DeleteAllAsync<Bar>());
+            Assert.True(await con.DeleteAllAsync<Bar>() > 0);
             Assert.Empty(await con.GetAllAsync<Bar>());
         }
 

--- a/test/Dommel.Json.IntegrationTests/DeleteTests.cs
+++ b/test/Dommel.Json.IntegrationTests/DeleteTests.cs
@@ -45,7 +45,7 @@ namespace Dommel.Json.IntegrationTests
         {
             using var con = database.GetConnection();
             var id = InsertLead(con);
-            Assert.True(con.DeleteMultiple<Lead>(p => p.Data!.Email == "foo@example.com"));
+            Assert.True(con.DeleteMultiple<Lead>(p => p.Data!.Email == "foo@example.com") > 0);
             var leads = con.Select<Lead>(p => p.Data!.Email == "foo@example.com");
             Assert.Empty(leads);
         }
@@ -56,7 +56,7 @@ namespace Dommel.Json.IntegrationTests
         {
             using var con = database.GetConnection();
             var id = await InsertLeadAsync(con);
-            Assert.True(await con.DeleteMultipleAsync<Lead>(p => p.Data!.Email == "foo@example.com"));
+            Assert.True(await con.DeleteMultipleAsync<Lead>(p => p.Data!.Email == "foo@example.com") > 0);
             var leads = await con.SelectAsync<Lead>(p => p.Data!.Email == "foo@example.com");
             Assert.Empty(leads);
         }
@@ -67,7 +67,7 @@ namespace Dommel.Json.IntegrationTests
         {
             using var con = database.GetConnection();
             var id = InsertLead(con);
-            Assert.True(con.DeleteMultiple<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" && p.Email == "foo@example.com"));
+            Assert.True(con.DeleteMultiple<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" && p.Email == "foo@example.com") > 0);
             var leads = con.Select<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" && p.Email == "foo@example.com");
             Assert.Empty(leads);
         }
@@ -78,7 +78,7 @@ namespace Dommel.Json.IntegrationTests
         {
             using var con = database.GetConnection();
             var id = await InsertLeadAsync(con);
-            Assert.True(await con.DeleteMultipleAsync<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" && p.Email == "foo@example.com"));
+            Assert.True(await con.DeleteMultipleAsync<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" && p.Email == "foo@example.com") > 0);
             var leads = await con.SelectAsync<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" && p.Email == "foo@example.com");
             Assert.Empty(leads);
         }
@@ -89,7 +89,7 @@ namespace Dommel.Json.IntegrationTests
         {
             using var con = database.GetConnection();
             var id = InsertLead(con);
-            Assert.True(con.DeleteMultiple<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" || p.Email == "foo@example.com"));
+            Assert.True(con.DeleteMultiple<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" || p.Email == "foo@example.com") > 0);
             var leads = con.Select<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" || p.Email == "foo@example.com");
             Assert.Empty(leads);
         }
@@ -100,7 +100,7 @@ namespace Dommel.Json.IntegrationTests
         {
             using var con = database.GetConnection();
             var id = await InsertLeadAsync(con);
-            Assert.True(await con.DeleteMultipleAsync<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" || p.Email == "foo@example.com"));
+            Assert.True(await con.DeleteMultipleAsync<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" || p.Email == "foo@example.com") > 0);
             var leads = await con.SelectAsync<Lead>(p => p.Data!.FirstName == "Foo" && p.Data.LastName == "Bar" || p.Email == "foo@example.com");
             Assert.Empty(leads);
         }


### PR DESCRIPTION
My suggestion is to return the number of rows deleted in methods DeleteMultiple, DeleteMultipleAsync, DeleteAll and DeleteAllAsync.
This is a very good and common practice, it helps for logging affected (deleted) rows and other purposes without the need for additional requests.