### PR TITLE
Quote schema and table name separately

### DIFF
--- a/src/Dommel/Resolvers.cs
+++ b/src/Dommel/Resolvers.cs
@@ -100,7 +100,21 @@ namespace Dommel
             var key = $"{sqlBuilder.GetType()}.{type}";
             if (!TypeTableNameCache.TryGetValue(key, out var name))
             {
-                name = sqlBuilder.QuoteIdentifier(DommelMapper.TableNameResolver.ResolveTableName(type));
+                var tableName = DommelMapper.TableNameResolver.ResolveTableName(type);
+
+                // Dots are used to define a schema which should be quoted separately
+                if (tableName.Contains('.'))
+                {
+                    name = string.Join(".", DommelMapper.TableNameResolver
+                        .ResolveTableName(type)
+                        .Split('.')
+                        .Select(x => sqlBuilder.QuoteIdentifier(x)));
+                }
+                else
+                {
+                    name = sqlBuilder.QuoteIdentifier(tableName);
+                }
+
                 TypeTableNameCache.TryAdd(key, name);
             }
 

--- a/test/Dommel.Tests/ResolversTests.cs
+++ b/test/Dommel.Tests/ResolversTests.cs
@@ -8,6 +8,13 @@ namespace Dommel.Tests
         private readonly ISqlBuilder _sqlBuilder = new SqlServerSqlBuilder();
 
         [Fact]
+        public void Table_WithSchema()
+        {
+            Assert.Equal("[dbo].[Qux]", Resolvers.Table(typeof(FooQux), _sqlBuilder));
+            Assert.Equal("[foo].[dbo].[Qux]", Resolvers.Table(typeof(FooDboQux), _sqlBuilder));
+        }
+
+        [Fact]
         public void Table_NoCacheConflictNestedClass()
         {
             Assert.Equal("[BarA]", Resolvers.Table(typeof(Foo.Bar), _sqlBuilder));
@@ -68,6 +75,18 @@ namespace Dommel.Tests
             {
                 public int BarId { get; set; }
             }
+        }
+
+        [Table("Qux", Schema = "foo.dbo")]
+        public class FooDboQux
+        {
+            public int Id { get; set; }
+        }
+
+        [Table("Qux", Schema = "dbo")]
+        public class FooQux
+        {
+            public int Id { get; set; }
         }
     }
 }


### PR DESCRIPTION
Dots are generally used by database systems to split schema and table names in queries. This commit implements a quickfix to quote both the schema('s) and table name separately rather than in a single quote. E.g. `[dbo].[Products]` vs. `[dbo.Products]`.

Fixes #189 