### PR TITLE
Only target .NET Standard 2.0

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -40,25 +40,25 @@ echo "build: Calculating code coverage metrics"
 # Test coverage for Dommel
 
 # Create the first coverage in the coverlet JSON format to allow merging
-exec { & dotnet test test/Dommel.Tests -c Release -f netcoreapp3.1 --no-build /p:CollectCoverage=true }
+exec { & dotnet test test/Dommel.Tests -c Release --no-build /p:CollectCoverage=true }
 
 # Merge this coverage output with the previous coverage output, this time
 # create a report using the opencover format which codecov can parse
 Push-Location -Path "test/Dommel.IntegrationTests"
-exec { & dotnet test -c Release -f netcoreapp3.1 --no-build /p:CollectCoverage=true /p:MergeWith="..\Dommel.Tests\coverage.netcoreapp3.1.json" /p:CoverletOutputFormat=opencover }
+exec { & dotnet test -c Release --no-build /p:CollectCoverage=true /p:MergeWith="..\Dommel.Tests\coverage.json" /p:CoverletOutputFormat=opencover }
 if ($env:APPVEYOR_BUILD_NUMBER) {
-    exec { & codecov -f "coverage.netcoreapp3.1.opencover.xml" }
+    exec { & codecov -f "coverage.opencover.xml" }
 }
 Pop-Location
 
 #
 # Test coverage for Dommel.Json
-exec { & dotnet test test/Dommel.Json.Tests -c Release -f netcoreapp3.1 --no-build /p:CollectCoverage=true /p:Include="[Dommel.Json]*" }
+exec { & dotnet test test/Dommel.Json.Tests -c Release --no-build /p:CollectCoverage=true /p:Include="[Dommel.Json]*" }
 
 Push-Location -Path "test/Dommel.Json.IntegrationTests"
-exec { & dotnet test -c Release -f netcoreapp3.1 --no-build /p:CollectCoverage=true /p:Include="[Dommel.Json]*" /p:MergeWith="..\Dommel.Json.Tests\coverage.netcoreapp3.1.json" /p:CoverletOutputFormat=opencover }
+exec { & dotnet test -c Release --no-build /p:CollectCoverage=true /p:Include="[Dommel.Json]*" /p:MergeWith="..\Dommel.Json.Tests\coverage.json" /p:CoverletOutputFormat=opencover }
 if ($env:APPVEYOR_BUILD_NUMBER) {
-    exec { & codecov -f "coverage.netcoreapp3.1.opencover.xml" }
+    exec { & codecov -f "coverage.opencover.xml" }
 }
 Pop-Location
 

--- a/src/Dommel.Json/Dommel.Json.csproj
+++ b/src/Dommel.Json/Dommel.Json.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>JSON support for Dommel.</Description>
-    <Copyright>Copyright © Henk Mollema 2019</Copyright>
+    <Copyright>Copyright © Henk Mollema 2020</Copyright>
     <VersionPrefix>1.0.0-beta2</VersionPrefix>
     <Authors>Henk Mollema</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Dommel/Dommel.csproj
+++ b/src/Dommel/Dommel.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple CRUD operations for Dapper.</Description>
-    <Copyright>Copyright © Henk Mollema 2019</Copyright>
+    <Copyright>Copyright © Henk Mollema 2020</Copyright>
     <AssemblyTitle>Dommel</AssemblyTitle>
     <VersionPrefix>2.0.0-beta7</VersionPrefix>
     <Authors>Henk Mollema</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Dommel.IntegrationTests/Dommel.IntegrationTests.csproj
+++ b/test/Dommel.IntegrationTests/Dommel.IntegrationTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/test/Dommel.Json.IntegrationTests/Dommel.Json.IntegrationTests.csproj
+++ b/test/Dommel.Json.IntegrationTests/Dommel.Json.IntegrationTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/test/Dommel.Json.Tests/Dommel.Json.Tests.csproj
+++ b/test/Dommel.Json.Tests/Dommel.Json.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/test/Dommel.Tests/Dommel.Tests.csproj
+++ b/test/Dommel.Tests/Dommel.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Simplify development by only targeting .NET Standard 2.0 and .NET Core 3.1 for tests.