### PR TITLE
Added parentheses when AndAlso and OrElse expressions are combined

### DIFF
--- a/test/Dommel.Tests/SqlExpressions/BooleanExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/BooleanExpressionTests.cs
@@ -39,6 +39,15 @@ namespace Dommel.Tests
                 .ToSql();
             Assert.Equal(" where ([Baz] = '1' or [Qux] = '1')", sql);
         }
+        
+        [Fact]
+        public void MultipleOr()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Baz || f.Qux || f.Fuzz)
+                .ToSql();
+            Assert.Equal(" where ([Baz] = '1' or [Qux] = '1' or [Fuzz] = '1')", sql);
+        }
 
         [Fact]
         public void OrWithNot()
@@ -56,6 +65,15 @@ namespace Dommel.Tests
                 .Where(f => f.Baz && f.Qux)
                 .ToSql();
             Assert.Equal(" where ([Baz] = '1' and [Qux] = '1')", sql);
+        }
+        
+        [Fact]
+        public void MultipleAnd()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Baz && f.Qux && f.Fuzz)
+                .ToSql();
+            Assert.Equal(" where ([Baz] = '1' and [Qux] = '1' and [Fuzz] = '1')", sql);
         }
 
         [Fact]
@@ -76,6 +94,24 @@ namespace Dommel.Tests
             Assert.Equal(" where ([Bar] = @p1 or [Baz] = '1')", sql);
         }
 
+        [Fact]
+        public void CombinedWithMultipleStatementsWithParentheses()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Bar == "test" && (f.Baz || f.Qux) || f.Bar == null)
+                .ToSql();
+                Assert.Equal(" where (([Bar] = @p1 and ([Baz] = '1' or [Qux] = '1')) or [Bar] is null)", sql);
+        }
+
+        [Fact]
+        public void CombineWithMultipleStatementsWithoutParentheses()
+        { 
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Bar == "test" && f.Baz || f.Qux || f.Bar == null)
+                .ToSql();
+            Assert.Equal(" where (([Bar] = @p1 and [Baz] = '1') or [Qux] = '1' or [Bar] is null)", sql);
+        }
+
         public class Foo
         {
             public string? Bar { get; set; }
@@ -83,6 +119,8 @@ namespace Dommel.Tests
             public bool Baz { get; set; }
 
             public bool Qux { get; set; }
+
+            public bool Fuzz { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fix for issue #247