### PR TITLE
Improve SQL Expressions compiler

### DIFF
--- a/src/Dommel.Json/JsonSqlExpression.cs
+++ b/src/Dommel.Json/JsonSqlExpression.cs
@@ -15,16 +15,16 @@ namespace Dommel.Json
 
         public new IJsonSqlBuilder SqlBuilder => (IJsonSqlBuilder)base.SqlBuilder;
 
-        protected override object VisitMemberAccess(MemberExpression expression)
+        protected override VisitResult VisitMemberAccess(MemberExpression expression)
         {
             if (expression.Member is PropertyInfo jsonValue &&
                 expression.Expression is MemberExpression jsonContainerExpr &&
                 jsonContainerExpr.Member is PropertyInfo jsonContainer &&
                 jsonContainer.IsDefined(_options.JsonDataAttributeType))
             {
-                return SqlBuilder.JsonValue(
-                    VisitMemberAccess(jsonContainerExpr).ToString(),
-                    ColumnNameResolver.ResolveColumnName(jsonValue));
+                var memberAccessResult = VisitMemberAccess(jsonContainerExpr);
+                return new VisitResult(SqlBuilder.JsonValue(memberAccessResult.Result.ToString(),
+                    ColumnNameResolver.ResolveColumnName(jsonValue)));
             }
 
             return base.VisitMemberAccess(expression);

--- a/src/Dommel/SqlExpression.cs
+++ b/src/Dommel/SqlExpression.cs
@@ -400,8 +400,7 @@ namespace Dommel
             }
 
             var inClause = new StringBuilder("(");
-            foreach (var value in (System.Collections.IEnumerable) (VisitMemberAccess((MemberExpression) collection))
-                .Result)
+            foreach (var value in (System.Collections.IEnumerable) (VisitMemberAccess((MemberExpression) collection)).Result)
             {
                 AddParameter(value, out var paramName);
                 inClause.Append($"{paramName},");
@@ -426,7 +425,7 @@ namespace Dommel
         protected virtual VisitResult VisitContainsExpression(MethodCallExpression expression, TextSearch textSearch)
         {
             var column = VisitExpression(expression.Object);
-            if (expression.Arguments is {Count: 0 or > 1})
+            if (expression.Arguments.Count != 1)
             {
                 throw new ArgumentException("Contains-expression should contain exactly one argument.",
                     nameof(expression));
@@ -438,8 +437,7 @@ namespace Dommel
                 TextSearch.Contains => $"%{value}%",
                 TextSearch.StartsWith => $"{value}%",
                 TextSearch.EndsWith => $"%{value}",
-                _ => throw new ArgumentOutOfRangeException($"Invalid TextSearch value '{textSearch}'.",
-                    nameof(textSearch)),
+                _ => throw new ArgumentOutOfRangeException($"Invalid TextSearch value '{textSearch}'.", nameof(textSearch))
             };
             AddParameter(textLike, out var paramName);
 
@@ -466,7 +464,6 @@ namespace Dommel
             return VisitExpression(epxression.Body);
         }
 
-
         /// <summary>
         /// Verify if a particular <paramref name="expression"/> needs to be enclosed in parentheses
         /// given the <paramref name="parentExpression"/> 
@@ -477,14 +474,15 @@ namespace Dommel
         private static bool ShouldHaveParentheses(Expression expression, BinaryExpression parentExpression)
         {
             if (expression is not (BinaryExpression or UnaryExpression))
+            {
                 return false;
+            }
             var expressionOperatorLevel = GetOperatorPrecedence(expression.NodeType);
             var parentExpressionOperatorLevel = GetOperatorPrecedence(parentExpression.NodeType);
 
 
             return expressionOperatorLevel > parentExpressionOperatorLevel;
         }
-
 
         /// <summary>
         /// Processes a binary expression.
@@ -730,8 +728,7 @@ namespace Dommel
                 {
                     // When we're paging we'll need an order to guarantee consistent paging results, when
                     // the user did not specified an order themself we'll order on the PKs of the table.
-                    var keyColumns = Resolvers.KeyProperties(typeof(TEntity))
-                        .Select(p => Resolvers.Column(p.Property, SqlBuilder));
+                    var keyColumns = Resolvers.KeyProperties(typeof(TEntity)).Select(p => Resolvers.Column(p.Property, SqlBuilder));
                     AppendOrderBy(string.Join(", ", keyColumns), direction: "asc", prepend: true);
                     query += _orderByBuilder.ToString();
                 }

--- a/src/Dommel/SqlExpression.cs
+++ b/src/Dommel/SqlExpression.cs
@@ -14,8 +14,10 @@ namespace Dommel
     public class SqlExpression<TEntity>
     {
         private static readonly Type EntityType = typeof(TEntity);
+
         private static readonly Func<TEntity> NewEntityFunc = Expression.Lambda<Func<TEntity>>(
             Expression.New(typeof(TEntity).GetConstructors()[0])).Compile();
+
         private readonly StringBuilder _whereBuilder = new StringBuilder();
         private readonly StringBuilder _orderByBuilder = new StringBuilder();
         private readonly DynamicParameters _parameters = new DynamicParameters();
@@ -73,7 +75,8 @@ namespace Dommel
             var props = obj.GetType().GetProperties();
             if (props.Length == 0)
             {
-                throw new ArgumentException($"Projection over type '{typeof(TEntity).Name}' yielded no properties.", nameof(selector));
+                throw new ArgumentException($"Projection over type '{typeof(TEntity).Name}' yielded no properties.",
+                    nameof(selector));
             }
 
             var columns = props.Select(p => Resolvers.Column(p, SqlBuilder));
@@ -119,10 +122,12 @@ namespace Dommel
             {
                 throw new InvalidOperationException("Start the where statement with the 'Where' method.");
             }
+
             if (expression != null)
             {
                 AppendToWhere("and", expression);
             }
+
             return this;
         }
 
@@ -137,10 +142,12 @@ namespace Dommel
             {
                 throw new InvalidOperationException("Start the where statement with the 'Where' method.");
             }
+
             if (expression != null)
             {
                 AppendToWhere("or", expression);
             }
+
             return this;
         }
 
@@ -189,6 +196,11 @@ namespace Dommel
         /// <returns>The current <see cref="SqlExpression{TEntity}"/> instance.</returns>
         public virtual SqlExpression<TEntity> OrderBy(PropertyInfo property)
         {
+            if (property == null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
             AppendOrderBy(Resolvers.Column(property, SqlBuilder), direction: "asc");
             return this;
         }
@@ -211,6 +223,11 @@ namespace Dommel
         /// <returns>The current <see cref="SqlExpression{TEntity}"/> instance.</returns>
         public virtual SqlExpression<TEntity> OrderByDescending(PropertyInfo property)
         {
+            if (property == null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
             AppendOrderBy(Resolvers.Column(property, SqlBuilder), direction: "desc");
             return this;
         }
@@ -222,7 +239,7 @@ namespace Dommel
                 throw new ArgumentNullException(nameof(selector));
             }
 
-            var column = VisitExpression(selector.Body) as string;
+            var column = VisitExpression(selector.Body).ToString();
             AppendOrderBy(column, direction);
         }
 
@@ -232,10 +249,12 @@ namespace Dommel
             {
                 throw new ArgumentNullException(nameof(column));
             }
+
             if (string.IsNullOrEmpty(direction))
             {
                 throw new ArgumentNullException(nameof(direction));
             }
+
             if (_orderByBuilder.Length == 0)
             {
                 _orderByBuilder.Append($" order by {column} {direction}");
@@ -256,12 +275,12 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The expression to visit.</param>
         /// <returns>The result of the visit.</returns>
-        protected virtual object VisitExpression(Expression expression)
+        protected virtual VisitResult VisitExpression(Expression expression)
         {
             switch (expression.NodeType)
             {
                 case ExpressionType.Lambda:
-                    return VisitLambda((LambdaExpression)expression);
+                    return VisitLambda((LambdaExpression) expression);
 
                 case ExpressionType.LessThan:
                 case ExpressionType.LessThanOrEqual:
@@ -273,27 +292,33 @@ namespace Dommel
                 case ExpressionType.AndAlso:
                 case ExpressionType.Or:
                 case ExpressionType.OrElse:
-                    return VisitBinary((BinaryExpression)expression);
+                case ExpressionType.Add:
+                case ExpressionType.Subtract:
+                case ExpressionType.Multiply:
+                case ExpressionType.Divide:
+                case ExpressionType.Modulo:
+                    return VisitBinary((BinaryExpression) expression);
 
                 case ExpressionType.Convert:
+                case ExpressionType.Negate:
                 case ExpressionType.Not:
-                    return VisitUnary((UnaryExpression)expression);
+                    return VisitUnary((UnaryExpression) expression);
 
                 case ExpressionType.New:
-                    return VisitNew((NewExpression)expression);
+                    return VisitNew((NewExpression) expression);
 
                 case ExpressionType.MemberAccess:
-                    return VisitMemberAccess((MemberExpression)expression);
+                    return VisitMemberAccess((MemberExpression) expression);
 
                 case ExpressionType.Constant:
-                    return VisitConstantExpression((ConstantExpression)expression);
+                    return VisitConstantExpression((ConstantExpression) expression);
                 case ExpressionType.Call:
-                    return VisitCallExpression((MethodCallExpression)expression);
+                    return VisitCallExpression((MethodCallExpression) expression);
                 case ExpressionType.Invoke:
-                    return VisitExpression(((InvocationExpression)expression).Expression);
+                    return VisitExpression(((InvocationExpression) expression).Expression);
             }
 
-            return expression;
+            return new VisitResult(expression);
         }
 
         /// <summary>
@@ -322,7 +347,7 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The method call expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitCallExpression(MethodCallExpression expression)
+        protected virtual VisitResult VisitCallExpression(MethodCallExpression expression)
         {
             var method = expression.Method.Name.ToLower();
             switch (method)
@@ -341,11 +366,9 @@ namespace Dommel
                     return VisitContainsExpression(expression, TextSearch.StartsWith);
                 case "endswith":
                     return VisitContainsExpression(expression, TextSearch.EndsWith);
-                default:
-                    break;
             }
 
-            return expression;
+            return new VisitResult(expression);
         }
 
         /// <summary>
@@ -353,7 +376,7 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The method call expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitInExpression(MethodCallExpression expression)
+        protected virtual VisitResult VisitInExpression(MethodCallExpression expression)
         {
             Expression collection;
             Expression property;
@@ -377,18 +400,21 @@ namespace Dommel
             }
 
             var inClause = new StringBuilder("(");
-            foreach (var value in (System.Collections.IEnumerable)VisitMemberAccess((MemberExpression)collection))
+            foreach (var value in (System.Collections.IEnumerable) (VisitMemberAccess((MemberExpression) collection))
+                .Result)
             {
                 AddParameter(value, out var paramName);
                 inClause.Append($"{paramName},");
             }
+
             if (inClause.Length == 1)
             {
                 inClause.Append("null,");
             }
+
             inClause[inClause.Length - 1] = ')';
 
-            return $"{VisitExpression(property)} in {inClause}";
+            return new VisitResult($"{VisitExpression(property).Result} in {inClause}");
         }
 
         /// <summary>
@@ -397,12 +423,13 @@ namespace Dommel
         /// <param name="expression">The method call expression.</param>
         /// <param name="textSearch">Type of search.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitContainsExpression(MethodCallExpression expression, TextSearch textSearch)
+        protected virtual VisitResult VisitContainsExpression(MethodCallExpression expression, TextSearch textSearch)
         {
             var column = VisitExpression(expression.Object);
-            if (expression.Arguments.Count == 0 || expression.Arguments.Count > 1)
+            if (expression.Arguments is {Count: 0 or > 1})
             {
-                throw new ArgumentException("Contains-expression should contain exactly one argument.", nameof(expression));
+                throw new ArgumentException("Contains-expression should contain exactly one argument.",
+                    nameof(expression));
             }
 
             var value = VisitExpression(expression.Arguments[0]);
@@ -411,12 +438,13 @@ namespace Dommel
                 TextSearch.Contains => $"%{value}%",
                 TextSearch.StartsWith => $"{value}%",
                 TextSearch.EndsWith => $"%{value}",
-                _ => throw new ArgumentOutOfRangeException($"Invalid TextSearch value '{textSearch}'.", nameof(textSearch)),
+                _ => throw new ArgumentOutOfRangeException($"Invalid TextSearch value '{textSearch}'.",
+                    nameof(textSearch)),
             };
             AddParameter(textLike, out var paramName);
 
             // Use lower() to make the queries case-insensitive
-            return $"lower({column}) like lower({paramName})";
+            return new VisitResult($"lower({column}) like lower({paramName})");
         }
 
         /// <summary>
@@ -424,14 +452,14 @@ namespace Dommel
         /// </summary>
         /// <param name="epxression">The lambda expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitLambda(LambdaExpression epxression)
+        protected virtual VisitResult VisitLambda(LambdaExpression epxression)
         {
             if (epxression.Body.NodeType == ExpressionType.MemberAccess)
             {
                 var member = epxression.Body as MemberExpression;
                 if (member?.Expression != null)
                 {
-                    return $"{VisitMemberAccess(member)} = '1'";
+                    return new VisitResult($"{VisitMemberAccess(member)} = '1'");
                 }
             }
 
@@ -448,16 +476,13 @@ namespace Dommel
         /// <returns>True if parentheses are required</returns>
         private static bool ShouldHaveParentheses(Expression expression, BinaryExpression parentExpression)
         {
-            if (expression is not BinaryExpression binaryExpression) 
+            if (expression is not (BinaryExpression or UnaryExpression))
                 return false;
+            var expressionOperatorLevel = GetOperatorPrecedence(expression.NodeType);
+            var parentExpressionOperatorLevel = GetOperatorPrecedence(parentExpression.NodeType);
 
-            var isParentAndAlso = parentExpression.NodeType == ExpressionType.AndAlso;
-            var isParentOrElse = parentExpression.NodeType == ExpressionType.OrElse;
 
-            var isAndAlso = binaryExpression.NodeType == ExpressionType.AndAlso;
-            var isOrElse = binaryExpression.NodeType == ExpressionType.OrElse;
-
-            return isAndAlso && isParentOrElse || isOrElse && isParentAndAlso;
+            return expressionOperatorLevel > parentExpressionOperatorLevel;
         }
 
 
@@ -466,64 +491,92 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The binary expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitBinary(BinaryExpression expression)
+        protected virtual VisitResult VisitBinary(BinaryExpression expression)
         {
-            object left, right;
             var operand = GetOperant(expression.NodeType);
-            if (operand == "and" || operand == "or")
+
+            var andAlsoOrOrElse = operand is "and" or "or";
+
+            VisitResult left, right;
+
+            if (andAlsoOrOrElse && expression.Left is MemberExpression leftMember &&
+                leftMember.Expression?.NodeType == ExpressionType.Parameter)
             {
-                // Process left and right side of the "and/or" expression, e.g.:
-                // Foo == 42    or      Bar == 42
-                //   left    operand     right
-                //
-                if (expression.Left is MemberExpression leftMember && leftMember.Expression?.NodeType == ExpressionType.Parameter)
-                {
-                    left = $"{VisitMemberAccess(leftMember)} = '1'";
-                }
-                else
-                {
-                    left = VisitExpression(expression.Left);
-                    if (ShouldHaveParentheses(expression.Left, expression))
-                        left = $"({left})";
-
-                }
-
-                if (expression.Right is MemberExpression rightMember && rightMember.Expression?.NodeType == ExpressionType.Parameter)
-                {
-                    right = $"{VisitMemberAccess(rightMember)} = '1'";
-                }
-                else
-                {
-                    right = VisitExpression(expression.Right);
-                    if (ShouldHaveParentheses(expression.Right, expression))
-                        right = $"({right})";
-
-                }
+                left = new VisitResult($"{VisitMemberAccess(leftMember).Result} = '1'");
             }
             else
             {
-                // It's a single expression, e.g. Foo == 42
                 left = VisitExpression(expression.Left);
-                right = VisitExpression(expression.Right);
-
-                if (right == null)
-                {
-                    // Special case 'is (not) null' syntax
-                    if (expression.NodeType == ExpressionType.Equal)
-                    {
-                        return $"{left} is null";
-                    }
-                    else
-                    {
-                        return $"{left} is not null";
-                    }
-                }
-
-                AddParameter(right, out var paramName);
-                return $"{left} {operand} {paramName}";
             }
 
-            return $"{left} {operand} {right}";
+            if (andAlsoOrOrElse && expression.Right is MemberExpression rightMember &&
+                rightMember.Expression?.NodeType == ExpressionType.Parameter)
+            {
+                right = new VisitResult($"{VisitMemberAccess(rightMember).Result} = '1'");
+            }
+            else
+            {
+                right = VisitExpression(expression.Right);
+            }
+
+            var resultBuilder = new StringBuilder();
+
+            if (left.Result == null)
+            {
+                // Special case 'is (not) null' syntax
+                resultBuilder.Append(expression.NodeType == ExpressionType.Equal
+                    ? $"{right.Result} is null"
+                    : $"{right.Result} is not null");
+
+                return new VisitResult(resultBuilder.ToString());
+            }
+
+            if (right.Result == null)
+            {
+                // Special case 'is (not) null' syntax
+                resultBuilder.Append(expression.NodeType == ExpressionType.Equal
+                    ? $"{left.Result} is null"
+                    : $"{left.Result} is not null");
+                return new VisitResult(resultBuilder.ToString());
+            }
+
+            if (!(left.IsConstantValue || right.IsConstantValue))
+            {
+                var leftNeedsParentheses = ShouldHaveParentheses(expression.Left, expression);
+                var rightNeedsParentheses = ShouldHaveParentheses(expression.Right, expression);
+                if (leftNeedsParentheses)
+                    resultBuilder.Append("(");
+
+                resultBuilder.Append(left.Result);
+
+                if (leftNeedsParentheses)
+                    resultBuilder.Append(")");
+
+                resultBuilder.Append($" {operand} ");
+
+                if (rightNeedsParentheses)
+                    resultBuilder.Append("(");
+
+                resultBuilder.Append(right.Result);
+
+                if (rightNeedsParentheses)
+                    resultBuilder.Append(")");
+
+                return new VisitResult(resultBuilder.ToString());
+            }
+
+            string paramName;
+            if (left.IsConstantValue)
+            {
+                AddParameter(left.Result, out paramName);
+
+                resultBuilder.Append($"{paramName} {operand} {right.Result}");
+                return new VisitResult(resultBuilder.ToString());
+            }
+
+            AddParameter(right.Result, out paramName);
+            resultBuilder.Append($"{left.Result} {operand} {paramName}");
+            return new VisitResult(resultBuilder.ToString());
         }
 
         /// <summary>
@@ -531,28 +584,33 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The unary expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitUnary(UnaryExpression expression)
+        protected virtual VisitResult VisitUnary(UnaryExpression expression)
         {
             switch (expression.NodeType)
             {
+                case ExpressionType.Negate:
+                    return new VisitResult($"-{VisitExpression(expression.Operand).Result}");
                 case ExpressionType.Not:
-                    var o = VisitExpression(expression.Operand);
+                    var visitResult = VisitExpression(expression.Operand);
+                    object o = visitResult.Result;
                     if (!(o is string))
                     {
-                        return !(bool)o;
+                        return new VisitResult(!(bool) o);
                     }
 
-                    if (expression.Operand is MemberExpression)
+                    if (expression.Operand is MemberExpression memberExpression &&
+                        memberExpression.Type == typeof(bool))
                     {
-                        o = $"{o} = '1'";
+                        o = $"({o} = '1')";
                     }
 
-                    return $"not ({o})";
+                    return new VisitResult($"not {o}");
                 case ExpressionType.Convert:
                     if (expression.Method != null)
                     {
-                        return Expression.Lambda(expression).Compile().DynamicInvoke();
+                        return new VisitResult(Expression.Lambda(expression).Compile().DynamicInvoke());
                     }
+
                     break;
             }
 
@@ -564,12 +622,12 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The new expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitNew(NewExpression expression)
+        protected virtual VisitResult VisitNew(NewExpression expression)
         {
             var member = Expression.Convert(expression, typeof(object));
             var lambda = Expression.Lambda<Func<object>>(member);
             var getter = lambda.Compile();
-            return getter();
+            return new VisitResult(getter(), true);
         }
 
         /// <summary>
@@ -577,17 +635,17 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The member access expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitMemberAccess(MemberExpression expression)
+        protected virtual VisitResult VisitMemberAccess(MemberExpression expression)
         {
             if (expression.Expression?.NodeType == ExpressionType.Parameter)
             {
-                return MemberToColumn(expression);
+                return new VisitResult(MemberToColumn(expression));
             }
 
             var member = Expression.Convert(expression, typeof(object));
             var lambda = Expression.Lambda<Func<object>>(member);
             var getter = lambda.Compile();
-            return getter();
+            return new VisitResult(getter());
         }
 
         /// <summary>
@@ -595,7 +653,8 @@ namespace Dommel
         /// </summary>
         /// <param name="expression">The constant expression.</param>
         /// <returns>The result of the processing.</returns>
-        protected virtual object VisitConstantExpression(ConstantExpression expression) => expression.Value;
+        protected virtual VisitResult VisitConstantExpression(ConstantExpression expression) =>
+            new VisitResult(expression.Value, true);
 
         /// <summary>
         /// Proccesses a member expression.
@@ -603,7 +662,7 @@ namespace Dommel
         /// <param name="expression">The member expression.</param>
         /// <returns>The result of the processing.</returns>
         protected virtual string MemberToColumn(MemberExpression expression) =>
-            Resolvers.Column((PropertyInfo)expression.Member, SqlBuilder);
+            Resolvers.Column((PropertyInfo) expression.Member, SqlBuilder);
 
         /// <summary>
         /// Returns the expression operant for the specified expression type.
@@ -654,27 +713,32 @@ namespace Dommel
             {
                 query += _selectQuery;
             }
+
             if (!string.IsNullOrEmpty(where))
             {
                 query += where;
             }
+
             if (!string.IsNullOrEmpty(orderBy))
             {
                 query += orderBy;
             }
+
             if (!string.IsNullOrEmpty(_pagingQuery))
             {
                 if (string.IsNullOrEmpty(orderBy))
                 {
                     // When we're paging we'll need an order to guarantee consistent paging results, when
                     // the user did not specified an order themself we'll order on the PKs of the table.
-                    var keyColumns = Resolvers.KeyProperties(typeof(TEntity)).Select(p => Resolvers.Column(p.Property, SqlBuilder));
+                    var keyColumns = Resolvers.KeyProperties(typeof(TEntity))
+                        .Select(p => Resolvers.Column(p.Property, SqlBuilder));
                     AppendOrderBy(string.Join(", ", keyColumns), direction: "asc", prepend: true);
                     query += _orderByBuilder.ToString();
                 }
 
                 query += _pagingQuery;
             }
+
             return query;
         }
 
@@ -694,5 +758,64 @@ namespace Dommel
         /// </summary>
         /// <returns>The current SQL query.</returns>
         public override string ToString() => ToSql();
+
+        protected static short GetOperatorPrecedence(ExpressionType expressionType)
+        {
+            switch (expressionType)
+            {
+                case ExpressionType.Negate:
+                    return 1;
+                case ExpressionType.Multiply:
+                case ExpressionType.Divide:
+                case ExpressionType.Modulo:
+                    return 2;
+                case ExpressionType.Add:
+                case ExpressionType.Subtract:
+                case ExpressionType.Or:
+                case ExpressionType.And:
+                    return 3;
+                case ExpressionType.LessThan:
+                case ExpressionType.LessThanOrEqual:
+                case ExpressionType.GreaterThan:
+                case ExpressionType.GreaterThanOrEqual:
+                case ExpressionType.Equal:
+                case ExpressionType.NotEqual:
+                    return 4;
+                case ExpressionType.Not:
+                    return 5;
+                case ExpressionType.AndAlso:
+                    return 6;
+                case ExpressionType.OrElse:
+                    return 7;
+                default:
+                    return 8;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        protected struct VisitResult
+        {
+            public object Result { get; private set; }
+
+            public bool IsConstantValue { get; private set; }
+
+            public VisitResult(object result)
+            {
+                Result = result;
+                IsConstantValue = false;
+            }
+
+            public VisitResult(object result, bool isConstantValue) : this(result)
+            {
+                IsConstantValue = isConstantValue;
+            }
+
+            public override string ToString()
+            {
+                return Result.ToString();
+            }
+        }
     }
 }

--- a/src/Dommel/SqlExpression.cs
+++ b/src/Dommel/SqlExpression.cs
@@ -480,7 +480,6 @@ namespace Dommel
             var expressionOperatorLevel = GetOperatorPrecedence(expression.NodeType);
             var parentExpressionOperatorLevel = GetOperatorPrecedence(parentExpression.NodeType);
 
-
             return expressionOperatorLevel > parentExpressionOperatorLevel;
         }
 

--- a/test/Dommel.Tests/SqlExpressions/BinaryExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/BinaryExpressionTests.cs
@@ -1,0 +1,262 @@
+﻿using Xunit;
+
+namespace Dommel.Tests
+{
+    public class BinaryExpressionTests
+    {
+        [Fact]
+        public void TwoConstants()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => "test" == "3")
+                .ToSql();
+            Assert.Equal(" where (False)", sql);
+        }
+        
+        [Fact]
+        public void GreaterThan()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 > f.Value2)
+                .ToSql();
+            Assert.Equal(" where ([Value1] > [Value2])", sql);
+        }
+        
+        [Fact]
+        public void GreaterThanWithLeftConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => 500 > f.Value2)
+                .ToSql();
+            Assert.Equal(" where (@p1 > [Value2])", sql);
+        }
+        
+        [Fact]
+        public void GreaterThanWithRightConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 > 157)
+                .ToSql();
+            Assert.Equal(" where ([Value1] > @p1)", sql);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqual()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 >= f.Value2)
+                .ToSql();
+            Assert.Equal(" where ([Value1] >= [Value2])", sql);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqualWithLeftConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => 200 >= f.Value2)
+                .ToSql();
+            Assert.Equal(" where (@p1 >= [Value2])", sql);
+        }
+        
+        [Fact]
+        public void GreaterThanOrEqualWithRightConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 >= 20)
+                .ToSql();
+            Assert.Equal(" where ([Value1] >= @p1)", sql);
+        }
+
+        [Fact]
+        public void LessThan()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 < f.Value2)
+                .ToSql();
+            Assert.Equal(" where ([Value1] < [Value2])", sql);
+        }
+        
+        [Fact]
+        public void LessThanWithLeftConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => 20 < f.Value2)
+                .ToSql();
+            Assert.Equal(" where (@p1 < [Value2])", sql);
+        }
+        
+        [Fact]
+        public void LessThanWithRightConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 < 10)
+                .ToSql();
+            Assert.Equal(" where ([Value1] < @p1)", sql);
+        }
+        
+        [Fact]
+        public void LessThanOrEqual()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 <= f.Value2)
+                .ToSql();
+            Assert.Equal(" where ([Value1] <= [Value2])", sql);
+        }
+        
+        [Fact]
+        public void LessThanOrEqualWithLeftConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => 15 <= f.Value2)
+                .ToSql();
+            Assert.Equal(" where (@p1 <= [Value2])", sql);
+        }
+        
+        [Fact]
+        public void LessThanOrEqualWithRightConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 <= 12)
+                .ToSql();
+            Assert.Equal(" where ([Value1] <= @p1)", sql);
+        }
+        
+        [Fact]
+        public void Add()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 + f.Value2 > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] + [Value2] > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void AddWithConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 + 10 > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] + @p1 > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void Subtract()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 - f.Value2) > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] - [Value2] > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void SubtractWithConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 - 20) > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] - @p1 > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void Multiply()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 * f.Value2) > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] * [Value2] > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void MultiplyWithConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (30 * f.Value2) > f.Value3)
+                .ToSql();
+            Assert.Equal(" where (@p1 * [Value2] > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void Modulo()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 % f.Value2)  > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] MOD [Value2] > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void ModuloWithConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 % 16)  > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] MOD @p1 > [Value3])", sql);
+        }
+        
+        
+        [Fact]
+        public void Divide()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 / f.Value2)  > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] / [Value2] > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void DivideWithConstant()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 / 16)  > f.Value3)
+                .ToSql();
+            Assert.Equal(" where ([Value1] / @p1 > [Value3])", sql);
+        }
+        
+        [Fact]
+        public void AndAlso()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Check1 && f.Check2)
+                .ToSql();
+            Assert.Equal(" where ([Check1] = '1' and [Check2] = '1')", sql);
+        }
+        
+        [Fact]
+        public void OrElse()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Check1 || f.Check2)
+                .ToSql();
+            Assert.Equal(" where ([Check1] = '1' or [Check2] = '1')", sql);
+        }
+        
+        [Fact]
+        public void MultipleArithmeticAndLogic()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Value1 * f.Value2 / (f.Value3 + f.Value2) > f.Value1)
+                .ToSql();
+            Assert.Equal(" where ([Value1] * [Value2] / ([Value3] + [Value2]) > [Value1])", sql);
+        }
+        
+        
+        [Fact]
+        public void MultipleArithmeticAndLogicWithParentheses()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => (f.Value1 + f.Value2) * f.Value3 > 0)
+                .ToSql();
+            Assert.Equal(" where (([Value1] + [Value2]) * [Value3] > @p1)", sql);
+        }
+
+        private class Foo
+        {
+            public int Value1 { get; set; }
+            public int Value2 { get; set; }
+            public int Value3 { get; set; }
+            
+            public bool Check1 { get; set; }
+            public bool Check2 { get; set; }
+        }
+    }
+}

--- a/test/Dommel.Tests/SqlExpressions/BooleanExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/BooleanExpressionTests.cs
@@ -100,7 +100,7 @@ namespace Dommel.Tests
             var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
                 .Where(f => f.Bar == "test" && (f.Baz || f.Qux) || f.Bar == null)
                 .ToSql();
-                Assert.Equal(" where (([Bar] = @p1 and ([Baz] = '1' or [Qux] = '1')) or [Bar] is null)", sql);
+                Assert.Equal(" where ([Bar] = @p1 and ([Baz] = '1' or [Qux] = '1') or [Bar] is null)", sql);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace Dommel.Tests
             var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
                 .Where(f => f.Bar == "test" && f.Baz || f.Qux || f.Bar == null)
                 .ToSql();
-            Assert.Equal(" where (([Bar] = @p1 and [Baz] = '1') or [Qux] = '1' or [Bar] is null)", sql);
+            Assert.Equal(" where ([Bar] = @p1 and [Baz] = '1' or [Qux] = '1' or [Bar] is null)", sql);
         }
 
         public class Foo

--- a/test/Dommel.Tests/SqlExpressions/BooleanExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/BooleanExpressionTests.cs
@@ -39,6 +39,15 @@ namespace Dommel.Tests
                 .ToSql();
             Assert.Equal(" where ([Baz] = '1' or [Qux] = '1')", sql);
         }
+        
+        [Fact]
+        public void MultipleOr()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Baz || f.Qux || f.Fuzz)
+                .ToSql();
+            Assert.Equal(" where ([Baz] = '1' or [Qux] = '1' or [Fuzz] = '1')", sql);
+        }
 
         [Fact]
         public void OrWithNot()
@@ -56,6 +65,15 @@ namespace Dommel.Tests
                 .Where(f => f.Baz && f.Qux)
                 .ToSql();
             Assert.Equal(" where ([Baz] = '1' and [Qux] = '1')", sql);
+        }
+        
+        [Fact]
+        public void MultipleAnd()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Baz && f.Qux && f.Fuzz)
+                .ToSql();
+            Assert.Equal(" where ([Baz] = '1' and [Qux] = '1' and [Fuzz] = '1')", sql);
         }
 
         [Fact]
@@ -76,6 +94,24 @@ namespace Dommel.Tests
             Assert.Equal(" where ([Bar] = @p1 or [Baz] = '1')", sql);
         }
 
+        [Fact]
+        public void CombinedWithMultipleStatementsWithParentheses()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Bar == "test" && (f.Baz || f.Qux) || f.Bar == null)
+                .ToSql();
+                Assert.Equal(" where (([Bar] = @p1 and ([Baz] = '1' or [Qux] = '1')) or [Bar] is null)", sql);
+        }
+
+        [Fact]
+        public void CombineWithMultipleStatementsWithoutParentheses()
+        { 
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => f.Bar == "test" && f.Baz || f.Qux || f.Bar == null)
+                .ToSql();
+            Assert.Equal(" where (([Bar] = @p1 and [Baz] = '1') or [Qux] = '1' or [Bar] is null)", sql);
+        }
+
         public class Foo
         {
             public string? Bar { get; set; }
@@ -83,6 +119,8 @@ namespace Dommel.Tests
             public bool Baz { get; set; }
 
             public bool Qux { get; set; }
+
+            public bool Fuzz { get; set; }
         }
     }
 }

--- a/test/Dommel.Tests/SqlExpressions/DynamicExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/DynamicExpressionTests.cs
@@ -65,12 +65,12 @@ namespace Dommel.Tests
         [Fact]
         public void InExpression()
         {
-            var ids = new[] { 1, 2 };
-            var idList = new ArrayList { "1", "2" };
+            var ids = new[] {1, 2};
+            var idList = new ArrayList {"1", "2"};
             var guid1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
             var guid2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
-            var guidList = new List<Guid> { guid1, guid2 };
-            var decimalList = new List<decimal> { 1.0m, 2.0m };
+            var guidList = new List<Guid> {guid1, guid2};
+            var decimalList = new List<decimal> {1.0m, 2.0m};
             Expression<Func<Foo, bool>> expression = p =>
                 ids.Contains(p.Id) || idList.Contains(p.StringId) ||
                 decimalList.Contains(p.DecimalId) || guidList.Contains(p.Guid) ||
@@ -79,7 +79,9 @@ namespace Dommel.Tests
             var dommelExpression = _sqlExpression.Where(expression);
             var sql = dommelExpression.ToSql(out var dynamicParameters);
 
-            Assert.Equal("where ([Id] in (@p1,@p2) or [StringId] in (@p3,@p4) or [DecimalId] in (@p5,@p6) or [Guid] in (@p7,@p8) or lower([Bar]) like lower(@p9))", sql.Trim());
+            Assert.Equal(
+                "where ([Id] in (@p1,@p2) or [StringId] in (@p3,@p4) or [DecimalId] in (@p5,@p6) or [Guid] in (@p7,@p8) or lower([Bar]) like lower(@p9))",
+                sql.Trim());
             Assert.Equal(1, dynamicParameters.Get<int>("p1"));
             Assert.Equal(2, dynamicParameters.Get<int>("p2"));
             Assert.Equal("1", dynamicParameters.Get<string>("p3"));
@@ -89,7 +91,22 @@ namespace Dommel.Tests
             Assert.Equal(guid1, dynamicParameters.Get<Guid>("p7"));
             Assert.Equal(guid2, dynamicParameters.Get<Guid>("p8"));
             Assert.Equal("%testIn%", dynamicParameters.Get<string>("p9"));
+        }
+        
+        [Fact]
+        public void InWithEmptyArray()
+        {
+            var ids = new int[] {};
+            Expression<Func<Foo, bool>> expression = p =>
+                ids.Contains(p.Id);
 
+            var dommelExpression = _sqlExpression.Where(expression);
+            var sql = dommelExpression.ToSql(out var dynamicParameters);
+
+            Assert.Equal(
+                "where ([Id] in (null))",
+                sql.Trim());
+           
         }
 
         [Table("tblFoo")]

--- a/test/Dommel.Tests/SqlExpressions/LikeTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/LikeTests.cs
@@ -20,6 +20,7 @@ namespace Dommel.Tests
             Assert.Single(dynamicParameters.ParameterNames);
             Assert.Equal("%test%", dynamicParameters.Get<string>("p1"));
         }
+        
 
         [Fact]
         public void LikeOperandContainsVariable()

--- a/test/Dommel.Tests/SqlExpressions/LikeTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/LikeTests.cs
@@ -20,7 +20,6 @@ namespace Dommel.Tests
             Assert.Single(dynamicParameters.ParameterNames);
             Assert.Equal("%test%", dynamicParameters.Get<string>("p1"));
         }
-        
 
         [Fact]
         public void LikeOperandContainsVariable()

--- a/test/Dommel.Tests/SqlExpressions/NullExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/NullExpressionTests.cs
@@ -5,7 +5,7 @@ namespace Dommel.Tests
     public class NullExpressionTests
     {
         [Fact]
-        public void GeneratesCorrectIsEqualSyntax()
+        public void IsNullLeft()
         {
             var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
                 .Where(f => f.Bar == null)
@@ -14,7 +14,7 @@ namespace Dommel.Tests
         }
 
         [Fact]
-        public void GeneratesCorrectIsNotEqualSyntax()
+        public void IsNotNullLeft()
         {
             var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
                 .Where(f => f.Bar != null)
@@ -23,21 +23,21 @@ namespace Dommel.Tests
         }
 
         [Fact]
-        public void GeneratesInvalidIsEqualSyntaxForInvalidExpression()
+        public void IsNullRight()
         {
             var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
                 .Where(f => null == f.Bar)
                 .ToSql();
-            Assert.Equal(" where ( = @p1)", sql);
+            Assert.Equal(" where ([Bar] is null)", sql);
         }
 
         [Fact]
-        public void GeneratesInvalidIsNotEqualSyntaxForInvalidExpression()
+        public void IsNotNullRight()
         {
             var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
                 .Where(f => null != f.Bar)
                 .ToSql();
-            Assert.Equal(" where ( <> @p1)", sql);
+            Assert.Equal(" where ([Bar] is not null)", sql);
         }
 
         public class Foo

--- a/test/Dommel.Tests/SqlExpressions/OrderByTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/OrderByTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Dommel.Tests
+{
+    public class OrderByTests
+    {
+        
+        [Fact]
+        public void Asc()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderBy(f => f.Value1)
+                .ToSql();
+            Assert.Equal(" order by [Value1] asc", sql);
+        }
+        
+        [Fact]
+        public void AscProp()
+        {
+            var value1Prop = typeof(Foo).GetProperties().FirstOrDefault(p => p.Name == nameof(Foo.Value1));
+            
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderBy(value1Prop)
+                .ToSql();
+            Assert.Equal(" order by [Value1] asc", sql);
+        }
+        
+        [Fact]
+        public void AscMultiple()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderBy(f => f.Value1)
+                .OrderBy(f => f.Value2)
+                .ToSql();
+            Assert.Equal(" order by [Value1] asc, [Value2] asc", sql);
+        }
+        
+        [Fact]
+        public void Desc()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderByDescending(f => f.Value1)
+                .ToSql();
+            Assert.Equal(" order by [Value1] desc", sql);
+        }
+        
+        [Fact]
+        public void DescProp()
+        {
+            var value1Prop = typeof(Foo).GetProperties().FirstOrDefault(p => p.Name == nameof(Foo.Value1));
+            
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderByDescending(value1Prop)
+                .ToSql();
+            Assert.Equal(" order by [Value1] desc", sql);
+        }
+        
+        [Fact]
+        public void DescMultiple()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderByDescending(f => f.Value1)
+                .OrderByDescending(f => f.Value2)
+                .ToSql();
+            Assert.Equal(" order by [Value1] desc, [Value2] desc", sql);
+        }
+        
+        [Fact]
+        public void DescAsc()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderByDescending(f => f.Value1)
+                .OrderBy(f => f.Value2)
+                .ToSql();
+            Assert.Equal(" order by [Value1] desc, [Value2] asc", sql);
+        }
+        [Fact]
+        public void AscDesc()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .OrderBy(f => f.Value1)
+                .OrderByDescending(f => f.Value2)
+                .ToSql();
+            Assert.Equal(" order by [Value1] asc, [Value2] desc", sql);
+        }
+        
+        [Fact]
+        public void NullAscThrows()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                    .OrderBy((Expression<Func<Foo, object?>>) null)
+            );
+        }
+        
+        [Fact]
+        public void NullPropAscThrows()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                    .OrderBy((PropertyInfo) null)
+            );
+        }
+        
+        [Fact]
+        public void NullDescThrows()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                    .OrderByDescending((Expression<Func<Foo, object?>>) null)
+            );
+        }
+        
+        [Fact]
+        public void NullPropDescThrows()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                    .OrderByDescending((PropertyInfo) null)
+            );
+        }
+        
+        public class Foo
+        {
+            public int Value1 { get; set; }
+            public int Value2 { get; set; }
+            public int Value3 { get; set; }
+            
+            public bool Check1 { get; set; }
+            public bool Check2 { get; set; }
+        }
+    }
+}

--- a/test/Dommel.Tests/SqlExpressions/OrderByTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/OrderByTests.cs
@@ -8,7 +8,6 @@ namespace Dommel.Tests
 {
     public class OrderByTests
     {
-        
         [Fact]
         public void Asc()
         {

--- a/test/Dommel.Tests/SqlExpressions/SqlExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/SqlExpressionTests.cs
@@ -1,16 +1,27 @@
-﻿using Xunit;
+﻿using Dapper;
+using Xunit;
 
 namespace Dommel.Tests
 {
     public class SqlExpressionTests
     {
+        private readonly SqlExpression<Product> _sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
+
         [Fact]
         public void ToString_ReturnsSql()
         {
-            var _sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
             var sql = _sqlExpression.Where(p => p.Name == "Chai").ToSql();
             Assert.Equal(" where ([Name] = @p1)", sql);
             Assert.Equal(sql, _sqlExpression.ToString());
+        }
+
+        [Fact]
+        public void ParseNewExpression()
+        {
+            var sql = _sqlExpression.Where(p => p.Name == new string("Chai")).ToSql(out DynamicParameters parameters);
+            Assert.Equal(" where ([Name] = @p1)", sql);
+            Assert.Equal(sql, _sqlExpression.ToString());
+            Assert.Equal("Chai", parameters.Get<string>("p1"));
         }
     }
 }

--- a/test/Dommel.Tests/SqlExpressions/UnaryExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/UnaryExpressionTests.cs
@@ -1,0 +1,31 @@
+﻿using Xunit;
+
+namespace Dommel.Tests
+{
+    public class UnaryExpressionTests
+    {
+        [Fact]
+        public void Negate()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => -f.Value1 > 0 )
+                .ToSql();
+            Assert.Equal(" where (-[Value1] > @p1)", sql);
+        }
+        
+        [Fact]
+        public void Not()
+        {
+            var sql = new SqlExpression<Foo>(new SqlServerSqlBuilder())
+                .Where(f => !f.Check1 )
+                .ToSql();
+            Assert.Equal(" where (not ([Check1] = '1'))", sql);
+        }
+
+        private class Foo
+        {
+            public int Value1 { get; set; }
+            public bool Check1 { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I fixed issue #247 and also improved the SQL expression compiler.

Change List:
- added support for new operations (add, subtract, divide, multiply, modulo, negate)
- added support for operations that use two properties
- added support for operations with constants on the left side of the expression

In addition, I also added some tests to increase code coverage.