### PR TITLE
Fix the parameter prefix of insert queries

### DIFF
--- a/src/Dommel/Resolvers.cs
+++ b/src/Dommel/Resolvers.cs
@@ -84,6 +84,16 @@ namespace Dommel
         /// using the configured <see cref="ITableNameResolver"/>.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> to get the table name for.</param>
+        /// <param name="connection">The database connection instance.</param>
+        /// <returns>The table name in the database for <paramref name="type"/>.</returns>
+        public static string Table(Type type, IDbConnection connection) =>
+            Table(type, DommelMapper.GetSqlBuilder(connection));
+
+        /// <summary>
+        /// Gets the name of the table in the database for the specified type,
+        /// using the configured <see cref="ITableNameResolver"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to get the table name for.</param>
         /// <param name="sqlBuilder">The SQL builder instance.</param>
         /// <returns>The table name in the database for <paramref name="type"/>.</returns>
         public static string Table(Type type, ISqlBuilder sqlBuilder)

--- a/src/Dommel/Resolvers.cs
+++ b/src/Dommel/Resolvers.cs
@@ -78,15 +78,6 @@ namespace Dommel
 
             return properties;
         }
-        /// <summary>
-        /// Gets the name of the table in the database for the specified type,
-        /// using the configured <see cref="ITableNameResolver"/>.
-        /// </summary>
-        /// <param name="type">The <see cref="Type"/> to get the table name for.</param>
-        /// <param name="connection">The database connection instance.</param>
-        /// <returns>The table name in the database for <paramref name="type"/>.</returns>
-        public static string Table(Type type, IDbConnection connection) =>
-            Table(type, DommelMapper.GetSqlBuilder(connection));
 
         /// <summary>
         /// Gets the name of the table in the database for the specified type,

--- a/test/Dommel.IntegrationTests/ResolversTests.cs
+++ b/test/Dommel.IntegrationTests/ResolversTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Data.SqlClient;
+using System.ComponentModel.DataAnnotations.Schema;
+using Xunit;
+
+namespace Dommel.Tests
+{
+    public class ResolversTests
+    {
+        private readonly SqlConnection sqlConnection = new SqlConnection();
+
+        [Fact]
+        public void Table_WithSchema()
+        {
+            Assert.Equal("[dbo].[Qux]", Resolvers.Table(typeof(FooQux), sqlConnection));
+            Assert.Equal("[foo].[dbo].[Qux]", Resolvers.Table(typeof(FooDboQux), sqlConnection));
+        }
+
+        [Fact]
+        public void Table_NoCacheConflictNestedClass()
+        {
+            Assert.Equal("[BarA]", Resolvers.Table(typeof(Foo.Bar), sqlConnection));
+            Assert.Equal("[BarB]", Resolvers.Table(typeof(Baz.Bar), sqlConnection));
+        }
+
+        public class Foo
+        {
+            [Table("BarA")]
+            public class Bar
+            {
+                [Column("BazA")]
+                public string? Baz { get; set; }
+            }
+
+            [Table("BarA")]
+            public class BarChild
+            {
+                public int BarId { get; set; }
+            }
+        }
+
+        public class Baz
+        {
+            [Table("BarB")]
+            public class Bar
+            {
+                [Column("BazB")]
+                public string? Baz { get; set; }
+            }
+
+            [Table("BarA")]
+            public class BarChild
+            {
+                public int BarId { get; set; }
+            }
+        }
+
+        [Table("Qux", Schema = "foo.dbo")]
+        public class FooDboQux
+        {
+            public int Id { get; set; }
+        }
+
+        [Table("Qux", Schema = "dbo")]
+        public class FooQux
+        {
+            public int Id { get; set; }
+        }
+    }
+}

--- a/test/Dommel.Tests/ParameterPrefixTest.cs
+++ b/test/Dommel.Tests/ParameterPrefixTest.cs
@@ -31,6 +31,13 @@ namespace Dommel.Tests
         }
 
         [Fact]
+        public void TestInsert()
+        {
+            var sql = BuildInsertQuery(SqlBuilder, typeof(Foo));
+            Assert.Equal("insert into Foos (Bar) values (#Bar); select last_insert_rowid() id", sql);
+        }
+
+        [Fact]
         public void TestUpdate()
         {
             var sql = BuildUpdateQuery(SqlBuilder, typeof(Foo));


### PR DESCRIPTION
The **BuildInsertQuery** method was not using the ISqlBuilder.**PrefixParameter** method to add the prefix to the parameters.
It was instead always adding the "@" prefix. 

Line 90 of the Insert.cs file:
`var paramNames = typeProperties.Select(p => "@" + p.Name).ToArray();`

Since the methods **BuildUpdateQuery** and **BuildDeleteQuery** were using the PrefixParameter method, I did the same in the **BuildInsertQuery** method.

Also, in order to create a test case, I had to change the signature of the method BuildInsertQuery. These changes were based on the **BuildUpdateQuery** and **BuildDeleteQuery** methods. 

The signature before:
`private static string BuildInsertQuery(IDbConnection connection, Type type)` 

And now:
`internal static string BuildInsertQuery(ISqlBuilder sqlBuilder, Type type)`