### PR TITLE
Including table name on QueryCache

### DIFF
--- a/src/Dommel/Any.cs
+++ b/src/Dommel/Any.cs
@@ -68,10 +68,10 @@ namespace Dommel
 
         private static string BuildAnyPredicate(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Any, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Any, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 sql = $"select 1 from {tableName}";
                 QueryCache.TryAdd(cacheKey, sql);
             }

--- a/src/Dommel/Cache.cs
+++ b/src/Dommel/Cache.cs
@@ -20,11 +20,12 @@ namespace Dommel
 
     internal struct QueryCacheKey : IEquatable<QueryCacheKey>
     {
-        public QueryCacheKey(QueryCacheType cacheType, ISqlBuilder sqlBuilder, MemberInfo memberInfo)
+        public QueryCacheKey(QueryCacheType cacheType, ISqlBuilder sqlBuilder, MemberInfo memberInfo, string tableName)
         {
             SqlBuilderType = sqlBuilder.GetType();
             CacheType = cacheType;
             MemberInfo = memberInfo;
+            TableName = tableName;
         }
 
         public QueryCacheType CacheType { get; }
@@ -33,6 +34,15 @@ namespace Dommel
 
         public MemberInfo MemberInfo { get; }
 
-        public bool Equals(QueryCacheKey other) => CacheType == other.CacheType && SqlBuilderType == other.SqlBuilderType && MemberInfo == other.MemberInfo;
+        /// <summary>
+        /// Table name with schema
+        /// </summary>
+        public string TableName { get; }
+
+        public bool Equals(QueryCacheKey other) => 
+            CacheType == other.CacheType && 
+            SqlBuilderType == other.SqlBuilderType && 
+            MemberInfo == other.MemberInfo &&
+            TableName == other.TableName;
     }
 }

--- a/src/Dommel/Count.cs
+++ b/src/Dommel/Count.cs
@@ -68,10 +68,10 @@ namespace Dommel
 
         internal static string BuildCountAllSql(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Count, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Count, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 sql = $"select count(*) from {tableName}";
                 QueryCache.TryAdd(cacheKey, sql);
             }

--- a/src/Dommel/Delete.cs
+++ b/src/Dommel/Delete.cs
@@ -43,10 +43,10 @@ namespace Dommel
 
         internal static string BuildDeleteQuery(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Delete, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Delete, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 var keyProperties = Resolvers.KeyProperties(type);
                 var whereClauses = keyProperties.Select(p => $"{Resolvers.Column(p.Property, sqlBuilder)} = {sqlBuilder.PrefixParameter(p.Property.Name)}");
 
@@ -135,10 +135,10 @@ namespace Dommel
 
         internal static string BuildDeleteAllQuery(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.DeleteAll, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.DeleteAll, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 sql = $"delete from {tableName}";
                 QueryCache.TryAdd(cacheKey, sql);
             }

--- a/src/Dommel/Get.cs
+++ b/src/Dommel/Get.cs
@@ -46,10 +46,10 @@ namespace Dommel
 
         internal static string BuildGetById(ISqlBuilder sqlBuilder, Type type, object id, out DynamicParameters parameters)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Get, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Get, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 var keyProperties = Resolvers.KeyProperties(type);
                 if (keyProperties.Length > 1)
                 {
@@ -133,10 +133,10 @@ namespace Dommel
         internal static string BuildGetByIds(IDbConnection connection, Type type, object[] ids, out DynamicParameters parameters)
         {
             var sqlBuilder = GetSqlBuilder(connection);
-            var cacheKey = new QueryCacheKey(QueryCacheType.GetByMultipleIds, sqlBuilder, type);
+                var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.GetByMultipleIds, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 var keyProperties = Resolvers.KeyProperties(type);
                 var keyColumnNames = keyProperties.Select(p => Resolvers.Column(p.Property, sqlBuilder)).ToArray();
                 if (keyColumnNames.Length != ids.Length)
@@ -206,10 +206,11 @@ namespace Dommel
         internal static string BuildGetAllQuery(IDbConnection connection, Type type)
         {
             var sqlBuilder = GetSqlBuilder(connection);
-            var cacheKey = new QueryCacheKey(QueryCacheType.GetAll, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.GetAll, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                sql = "select * from " + Resolvers.Table(type, sqlBuilder);
+                sql = "select * from " + tableName;
                 QueryCache.TryAdd(cacheKey, sql);
             }
 

--- a/src/Dommel/Insert.cs
+++ b/src/Dommel/Insert.cs
@@ -76,11 +76,10 @@ namespace Dommel
 
         internal static string BuildInsertQuery(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Insert, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Insert, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
-
                 // Use all non-key and non-generated properties for inserts
                 var keyProperties = Resolvers.KeyProperties(type);
                 var typeProperties = Resolvers.Properties(type)

--- a/src/Dommel/Project.cs
+++ b/src/Dommel/Project.cs
@@ -41,7 +41,8 @@ namespace Dommel
 
         internal static string BuildProjectById(ISqlBuilder sqlBuilder, Type type, object id, out DynamicParameters parameters)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Project, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Project, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
                 var keyProperty = Resolvers.KeyProperties(type).Single().Property;
@@ -92,10 +93,10 @@ namespace Dommel
 
         internal static string BuildProjectAllQuery(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.ProjectAll, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.ProjectAll, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
                 var properties = Resolvers.Properties(type)
                     .Where(x => !x.IsGenerated)
                     .Select(x => x.Property)

--- a/src/Dommel/Update.cs
+++ b/src/Dommel/Update.cs
@@ -44,10 +44,10 @@ namespace Dommel
 
         internal static string BuildUpdateQuery(ISqlBuilder sqlBuilder, Type type)
         {
-            var cacheKey = new QueryCacheKey(QueryCacheType.Update, sqlBuilder, type);
+            var tableName = Resolvers.Table(type, sqlBuilder);
+            var cacheKey = new QueryCacheKey(QueryCacheType.Update, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
-                var tableName = Resolvers.Table(type, sqlBuilder);
 
                 // Use all non-key and non-generated properties for updates
                 var keyProperties = Resolvers.KeyProperties(type);

--- a/test/Dommel.Tests/CacheTests.cs
+++ b/test/Dommel.Tests/CacheTests.cs
@@ -18,7 +18,7 @@ namespace Dommel.Tests
         [InlineData(QueryCacheType.Any)]
         internal void SetsCache(QueryCacheType queryCacheType)
         {
-            var cacheKey = new QueryCacheKey(queryCacheType, new DummySqlBuilder(), typeof(Foo));
+            var cacheKey = new QueryCacheKey(queryCacheType, new DummySqlBuilder(), typeof(Foo), "table");
             DommelMapper.QueryCache[cacheKey] = "blah";
             Assert.Equal("blah", DommelMapper.QueryCache[cacheKey]);
         }
@@ -27,32 +27,32 @@ namespace Dommel.Tests
         public void IsEqual()
         {
             Assert.Equal(
-                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo)),
-                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo)));
+                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo), "table"),
+                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo), "table"));
         }
 
         [Fact]
         public void IsNotEqualCacheType()
         {
             Assert.NotEqual(
-                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo)),
-                new QueryCacheKey(QueryCacheType.GetAll, new DummySqlBuilder(), typeof(Foo)));
+                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo), "table"),
+                new QueryCacheKey(QueryCacheType.GetAll, new DummySqlBuilder(), typeof(Foo), "table"));
         }
 
         [Fact]
         public void IsNotEqualBuilderType()
         {
             Assert.NotEqual(
-                new QueryCacheKey(QueryCacheType.Get, new SqlServerSqlBuilder(), typeof(Foo)),
-                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo)));
+                new QueryCacheKey(QueryCacheType.Get, new SqlServerSqlBuilder(), typeof(Foo), "table"),
+                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo), "table"));
         }
 
         [Fact]
         public void IsNotEqualEntityType()
         {
             Assert.NotEqual(
-                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo)),
-                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Bar)));
+                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Foo), "table"),
+                new QueryCacheKey(QueryCacheType.Get, new DummySqlBuilder(), typeof(Bar), "table"));
         }
 
         private class Foo { }


### PR DESCRIPTION
I'm having problems with the Dommel query cache when using the same table on multiple schemas (when the database has multiple schemas and the same table in each). On my application I'm selecting the schema by user permissions from request, but the query is beeing generated always by the cache.

This PR fix it including the table name on QueryCache to avoid this kind of error.