### PR TITLE
Add bulk Delete and Update methods using SqlExpression

### DIFF
--- a/src/Dommel/Delete.cs
+++ b/src/Dommel/Delete.cs
@@ -149,4 +149,45 @@ public static partial class DommelMapper
 
         return sql;
     }
+
+    /// <summary>
+    /// Deletes the entities matching the specified predicate.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entity.</typeparam>
+    /// <param name="connection">The connection to the database. This can either be open or closed.</param>
+    /// <param name="sqlBuilder">A callback to build a <see cref="SqlExpression{TEntity}"/>.</param>
+    /// <param name="transaction">Optional transaction for the command.</param>
+    /// <returns>The number of rows affected.</returns>
+    public static int Delete<TEntity>(this IDbConnection connection, Action<SqlExpression<TEntity>> sqlBuilder, IDbTransaction? transaction = null)
+    {
+        var builder = GetSqlBuilder(connection);
+        var expression = CreateSqlExpression<TEntity>(builder);
+        sqlBuilder(expression);
+        var sql = expression.ToSql(out var parameters);
+        var table = Resolvers.Table(typeof(TEntity), builder);
+        sql = $"delete from {table}{sql}";
+        LogQuery<TEntity>(sql);
+        return connection.Execute(sql, parameters, transaction);
+    }
+
+    /// <summary>
+    /// Deletes the entities matching the specified predicate.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entity.</typeparam>
+    /// <param name="connection">The connection to the database. This can either be open or closed.</param>
+    /// <param name="sqlBuilder">A callback to build a <see cref="SqlExpression{TEntity}"/>.</param>
+    /// <param name="transaction">Optional transaction for the command.</param>
+    /// <param name="cancellationToken">Optional cancellation token for the command.</param>
+    /// <returns>The number of rows affected.</returns>
+    public static async Task<int> DeleteAsync<TEntity>(this IDbConnection connection, Action<SqlExpression<TEntity>> sqlBuilder, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+    {
+        var builder = GetSqlBuilder(connection);
+        var expression = CreateSqlExpression<TEntity>(builder);
+        sqlBuilder(expression);
+        var sql = expression.ToSql(out var parameters);
+        var table = Resolvers.Table(typeof(TEntity), builder);
+        sql = $"delete from {table}{sql}";
+        LogQuery<TEntity>(sql);
+        return await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: cancellationToken));
+    }
 }

--- a/test/Dommel.IntegrationTests/DynamicDeleteTests.cs
+++ b/test/Dommel.IntegrationTests/DynamicDeleteTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dommel.IntegrationTests;
+
+[Collection("Database")]
+public class DynamicDeleteTests
+{
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Delete_ByProductId_DeletesEntity(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product1 = new Product { Name = "Product 1", CategoryId = 1 };
+        var product2 = new Product { Name = "Product 2", CategoryId = 1 };
+        var product3 = new Product { Name = "Product 3", CategoryId = 2 };
+        await con.InsertAllAsync(new[] { product1, product2, product3 });
+
+        var initialCount = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(3, initialCount);
+
+        var affectedRows = await con.DeleteAsync<Product>(sql => sql.Where(p => p.ProductId == product1.ProductId));
+
+        Assert.Equal(1, affectedRows);
+        var remainingProducts = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(initialCount - 1, remainingProducts);
+        Assert.Null(await con.GetAsync<Product>(product1.ProductId));
+    }
+
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Delete_ByCategoryId_DeletesMultipleEntities(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product1 = new Product { Name = "Product 1", CategoryId = 1 };
+        var product2 = new Product { Name = "Product 2", CategoryId = 1 };
+        var product3 = new Product { Name = "Product 3", CategoryId = 2 };
+        await con.InsertAllAsync(new[] { product1, product2, product3 });
+
+        var initialCount = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(3, initialCount);
+
+        var affectedRows = await con.DeleteAsync<Product>(sql => sql.Where(p => p.CategoryId == 1));
+
+        Assert.Equal(2, affectedRows);
+        var remainingProducts = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(initialCount - 2, remainingProducts);
+        Assert.NotNull(await con.GetAsync<Product>(product3.ProductId));
+    }
+
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Delete_WithMultipleWhereClauses_DeletesCorrectEntities(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product1 = new Product { Name = "Product 1", CategoryId = 1 };
+        var product2 = new Product { Name = "Product 2", CategoryId = 1 };
+        var product3 = new Product { Name = "Product 3", CategoryId = 2 };
+        var product4 = new Product { Name = "Product 4", CategoryId = 2 };
+        await con.InsertAllAsync(new[] { product1, product2, product3, product4 });
+
+        var initialCount = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(4, initialCount);
+
+        var affectedRows = await con.DeleteAsync<Product>(sql => sql
+            .Where(p => p.CategoryId == 1)
+            .OrWhere(p => p.ProductId == product4.ProductId));
+
+        Assert.Equal(3, affectedRows);
+        var remainingProducts = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(initialCount - 3, remainingProducts);
+        Assert.Null(await con.GetAsync<Product>(product1.ProductId));
+        Assert.Null(await con.GetAsync<Product>(product2.ProductId));
+        Assert.NotNull(await con.GetAsync<Product>(product3.ProductId));
+        Assert.Null(await con.GetAsync<Product>(product4.ProductId));
+    }
+
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Delete_AllEntities(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product1 = new Product { Name = "Product 1", CategoryId = 1 };
+        var product2 = new Product { Name = "Product 2", CategoryId = 1 };
+        await con.InsertAllAsync(new[] { product1, product2 });
+
+        var initialCount = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(2, initialCount);
+
+        var affectedRows = await con.DeleteAsync<Product>(sql => sql.Where(p => true)); // Delete all
+
+        Assert.Equal(2, affectedRows);
+        var remainingProducts = (await con.GetAllAsync<Product>()).Count();
+        Assert.Equal(0, remainingProducts);
+    }
+}

--- a/test/Dommel.IntegrationTests/DynamicUpdateTests.cs
+++ b/test/Dommel.IntegrationTests/DynamicUpdateTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dommel.IntegrationTests;
+
+[Collection("Database")]
+public class DynamicUpdateTests
+{
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Update_ByProductId_UpdatesEntity(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product = new Product { Name = "Product 1", CategoryId = 1 };
+        await con.InsertAsync(product);
+
+        var affectedRows = await con.UpdateAsync<Product>(sql => sql
+            .Set(p => p.Name, "Updated Name")
+            .Where(p => p.ProductId == product.ProductId));
+
+        Assert.Equal(1, affectedRows);
+        var updatedProduct = await con.GetAsync<Product>(product.ProductId);
+        Assert.Equal("Updated Name", updatedProduct!.Name);
+    }
+
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Update_MultipleColumns_UpdatesEntity(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product = new Product { Name = "Product 1", CategoryId = 1 };
+        await con.InsertAsync(product);
+
+        var affectedRows = await con.UpdateAsync<Product>(sql => sql
+            .Set(p => p.Name, "Updated Name")
+            .Set(p => p.CategoryId, 2)
+            .Where(p => p.ProductId == product.ProductId));
+
+        Assert.Equal(1, affectedRows);
+        var updatedProduct = await con.GetAsync<Product>(product.ProductId);
+        Assert.Equal("Updated Name", updatedProduct!.Name);
+        Assert.Equal(2, updatedProduct.CategoryId);
+    }
+
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Update_MultipleEntities_UpdatesCorrectEntities(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product1 = new Product { Name = "Product 1", CategoryId = 1 };
+        var product2 = new Product { Name = "Product 2", CategoryId = 1 };
+        var product3 = new Product { Name = "Product 3", CategoryId = 2 };
+        await con.InsertAllAsync(new[] { product1, product2, product3 });
+
+        var affectedRows = await con.UpdateAsync<Product>(sql => sql
+            .Set(p => p.Name, "Updated Category 1 Product")
+            .Where(p => p.CategoryId == 1));
+
+        Assert.Equal(2, affectedRows);
+        
+        var updatedProduct1 = await con.GetAsync<Product>(product1.ProductId);
+        Assert.Equal("Updated Category 1 Product", updatedProduct1!.Name);
+
+        var updatedProduct2 = await con.GetAsync<Product>(product2.ProductId);
+        Assert.Equal("Updated Category 1 Product", updatedProduct2!.Name);
+
+        var unchangedProduct3 = await con.GetAsync<Product>(product3.ProductId);
+        Assert.Equal("Product 3", unchangedProduct3!.Name);
+    }
+
+    [Theory]
+    [ClassData(typeof(DatabaseTestData))]
+    public async Task Update_WithNullValue_UpdatesEntity(DatabaseDriver database)
+    {
+        using var con = database.GetConnection();
+        await con.DeleteAllAsync<Product>();
+
+        var product = new Product { Name = "Product 1", CategoryId = 1 };
+        await con.InsertAsync(product);
+
+        var affectedRows = await con.UpdateAsync<Product>(sql => sql
+            .Set(p => p.Name, null)
+            .Where(p => p.ProductId == product.ProductId));
+
+        Assert.Equal(1, affectedRows);
+        var updatedProduct = await con.GetAsync<Product>(product.ProductId);
+        Assert.Null(updatedProduct!.Name);
+    }
+}

--- a/test/Dommel.Tests/SqlExpressions/SetTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/SetTests.cs
@@ -1,0 +1,43 @@
+using System;
+using Xunit;
+
+namespace Dommel.Tests;
+
+public class SetTests
+{
+    private readonly SqlExpression<Product> _sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
+
+    [Fact]
+    public void Set_UpdatesColumn()
+    {
+        var sql = _sqlExpression.Set(p => p.Name, "Chai").ToSql();
+        Assert.Equal(" set [Products].[FullName] = @p1", sql);
+    }
+
+    [Fact]
+    public void Set_UpdatesMultipleColumns()
+    {
+        var sql = _sqlExpression
+            .Set(p => p.Name, "Chai")
+            .Set(p => p.CategoryId, 1)
+            .ToSql();
+        Assert.Equal(" set [Products].[FullName] = @p1, [Products].[CategoryId] = @p2", sql);
+    }
+
+    [Fact]
+    public void Set_WithWhere_ReturnsSql()
+    {
+        var sql = _sqlExpression
+            .Set(p => p.Name, "Chai")
+            .Where(p => p.Id == 1)
+            .ToSql();
+        Assert.Equal(" set [Products].[FullName] = @p1 where [Products].[Id] = @p2", sql);
+    }
+
+    [Fact]
+    public void Set_NullValue_ReturnsSql()
+    {
+        var sql = _sqlExpression.Set(p => p.Name, null).ToSql();
+        Assert.Equal(" set [Products].[FullName] = @p1", sql);
+    }
+}

--- a/test/Dommel.Tests/SqlExpressions/SqlExpressionTests.cs
+++ b/test/Dommel.Tests/SqlExpressions/SqlExpressionTests.cs
@@ -1,34 +1,40 @@
-﻿using System;
-
+using System;
 using Xunit;
 
 namespace Dommel.Tests;
 
 public class SqlExpressionTests
 {
+    private readonly SqlExpression<Product> _sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
+
     [Fact]
     public void ToString_ReturnsSql()
     {
-        var sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
-        var sql = sqlExpression.Where(p => p.Name == "Chai").ToSql();
+        var sql = _sqlExpression.Where(p => p.Name == "Chai").ToSql();
         Assert.Equal(" where [Products].[FullName] = @p1", sql);
-        Assert.Equal(sql, sqlExpression.ToString());
     }
 
     [Fact]
     public void ToStringVisitation_ReturnsSql()
     {
-        var sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
-        var sql = sqlExpression.Where(p => p.CategoryId.ToString() == "1").ToSql();
+        var sql = _sqlExpression.Where(p => p.CategoryId.ToString() == "1").ToSql();
         Assert.Equal(" where CAST([Products].[CategoryId] AS CHAR) = @p1", sql);
-        Assert.Equal(sql, sqlExpression.ToString());
     }
 
     [Fact]
     public void ToString_ThrowsWhenCalledWithArgument()
     {
-        var sqlExpression = new SqlExpression<Product>(new SqlServerSqlBuilder());
-        var ex = Assert.Throws<ArgumentException>(() => sqlExpression.Where(p => p.CategoryId.ToString("n2") == "1"));
+        var ex = Assert.Throws<ArgumentException>(() => _sqlExpression.Where(p => p.CategoryId.ToString("n2") == "1"));
         Assert.Contains("ToString-expression should not contain any argument.", ex.Message);
+    }
+
+    [Fact]
+    public void ToSql_ThrowsWhenSelectAndSetArePresent()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => _sqlExpression
+            .Select()
+            .Set(p => p.Name, "Chai")
+            .ToSql());
+        Assert.Equal("A SQL expression cannot contain both a Select and Set statement.", ex.Message);
     }
 }


### PR DESCRIPTION
Introduces new Delete and Update methods to DommelMapper that accept a SqlExpression builder for bulk operations. SqlExpression now supports building SET clauses for updates.