### PR TITLE
Fix DateOnlyTypeHandler

### DIFF
--- a/src/Dommel/DateOnlyTypeHandler.cs
+++ b/src/Dommel/DateOnlyTypeHandler.cs
@@ -8,7 +8,7 @@ namespace Dommel;
 internal class DateOnlyTypeHandler : SqlMapper.TypeHandler<DateOnly>
 {
     public override DateOnly Parse(object value) { 
-        if (value is DateOnly) return value;
+        if (value is DateOnly date) return date;
         return DateOnly.FromDateTime((DateTime)value);
     }
 

--- a/src/Dommel/DateOnlyTypeHandler.cs
+++ b/src/Dommel/DateOnlyTypeHandler.cs
@@ -7,7 +7,10 @@ namespace Dommel;
 #if NET6_0_OR_GREATER
 internal class DateOnlyTypeHandler : SqlMapper.TypeHandler<DateOnly>
 {
-    public override DateOnly Parse(object value) => DateOnly.FromDateTime((DateTime)value);
+    public override DateOnly Parse(object value) { 
+        if (value is DateOnly) return value;
+        return DateOnly.FromDateTime((DateTime)value);
+    }
 
     public override void SetValue(IDbDataParameter parameter, DateOnly value)
     {


### PR DESCRIPTION
Hello everybody, 
so after upgrading to net10.0 I was not able to parse `DateOnly`s aynmore.

Turns out the value received by the type handler was already a `DateOnly`.

To fix this while keeping it backwards compatible, I just added a type check.

Regards,
Benjamin